### PR TITLE
Read data_collection_date from master file as start_time

### DIFF
--- a/src/nexgen/beamlines/ED_singla_nxs.py
+++ b/src/nexgen/beamlines/ED_singla_nxs.py
@@ -14,6 +14,7 @@ from ..nxs_utils.ScanUtils import calculate_scan_points
 from ..nxs_write.NXmxWriter import EDNXmxFileWriter
 from ..nxs_write.write_utils import find_number_of_images
 from ..tools.ED_tools import extract_from_SINGLA_master, find_beam_centre
+from ..tools.ED_tools import extract_start_time_from_master
 from ..utils import coerce_to_path, find_in_dict, get_iso_timestamp, get_nexus_filename
 from .ED_params import ED_coord_system, EDSingla, EDSource
 
@@ -100,7 +101,7 @@ def singla_nexus_writer(
     if find_in_dict("start_time", params):
         start_time = get_iso_timestamp(params["start_time"])
     else:
-        start_time = None
+        start_time = extract_start_time_from_master(master_file)
 
     # Update source if new info passed
     source = EDSource

--- a/src/nexgen/beamlines/ED_singla_nxs.py
+++ b/src/nexgen/beamlines/ED_singla_nxs.py
@@ -15,6 +15,7 @@ from ..nxs_write.NXmxWriter import EDNXmxFileWriter
 from ..nxs_write.write_utils import find_number_of_images
 from ..tools.ED_tools import extract_from_SINGLA_master, find_beam_centre
 from ..tools.ED_tools import extract_start_time_from_master
+from ..tools.ED_tools import extract_exposure_time_from_master
 from ..utils import coerce_to_path, find_in_dict, get_iso_timestamp, get_nexus_filename
 from .ED_params import ED_coord_system, EDSingla, EDSource
 
@@ -145,6 +146,13 @@ def singla_nexus_writer(
     # Detector/module axes
     det_axes = EDSingla.det_axes
     det_axes[0].start_pos = det_distance
+
+    if not exp_time:
+        logger.warning("Exposure time not set, trying to read it from the master file.")
+        exp_time = extract_exposure_time_from_master(master_file)
+
+    if not exp_time:
+        raise ValueError("Exposure time not provided. No 'count_time' in the master file.")
 
     # Define detector
     detector = Detector(

--- a/src/nexgen/command_line/ED_nexus.py
+++ b/src/nexgen/command_line/ED_nexus.py
@@ -178,6 +178,12 @@ def write_from_SINGLA(args):
                 logger.warning(
                     f"Unable to calculate beam centre. It has been set to {beam_center}."
                 )
+
+        # Write data_collection_date from the master file as start_time
+        if not params.start_time:
+            params.start_time = det_info['data_collection_date']
+            logger.info('Data collection date read from the master file as start_time.')
+
     else:
         beam_center = (
             params.detector.beam_center if params.detector.beam_center else (0, 0)
@@ -185,6 +191,7 @@ def write_from_SINGLA(args):
 
     # Detector/ module axes
     det_axes = []
+
     for n, ax in enumerate(params.detector.axes):
         _tr = (
             TransformationType.TRANSLATION
@@ -267,7 +274,8 @@ def write_from_SINGLA(args):
             ED_coord_system,
             convert_to_mcstas=params.input.convert_to_mcstas,
         )
-        EDFileWriter.write(datafiles, data_entry_key)
+        EDFileWriter.write(datafiles, data_entry_key,
+                           start_time=params.start_time)
         if params.input.vds_writer:
             logger.info(
                 f"Calling VDS writer to write a Virtual Dataset{params.input.vds_writer}"

--- a/src/nexgen/tools/ED_tools.py
+++ b/src/nexgen/tools/ED_tools.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Tuple
 import h5py
 import hdf5plugin  # noqa: F401
 import numpy as np
+from datetime import datetime
 from numpy.typing import ArrayLike
 
 
@@ -134,6 +135,16 @@ class SinglaMaster:
             return None
         return self.__getitem__(_loc[0])[()]
 
+    def get_data_collection_date(self) -> str:
+        _loc = [obj for obj in self.walk if "data_collection_date" in obj]
+        if len(_loc) == 0:
+            return None
+        else:
+            collection_date = str(self.__getitem__(_loc[0])[()])[2:21]
+            collection_date = datetime.strptime(collection_date,
+                                                '%Y-%m-%dT%H:%M:%S')
+            return collection_date
+
 
 def extract_from_SINGLA_master(master: Path | str) -> Dict[str, Any]:
     """
@@ -173,6 +184,7 @@ def extract_from_SINGLA_master(master: Path | str) -> Dict[str, Any]:
         D["detector_number"] = singla.get_detector_number()
         D["detector_readout_time"] = singla.get_detector_readout_time()
         D["photon_energy"] = singla.get_photon_energy()
+        D["data_collection_date"] = singla.get_data_collection_date()
 
     return D
 

--- a/src/nexgen/tools/ED_tools.py
+++ b/src/nexgen/tools/ED_tools.py
@@ -155,6 +155,30 @@ class SinglaMaster:
             return collection_date
 
 
+def extract_start_time_from_master(master: Path | str) -> datetime:
+    """
+    Extracts `data_collection_data` from the master file
+
+    Args:
+        master (Path | str): Path to Singla master file.
+
+    Returns:
+        data collection date: Datetime object.
+    """
+    import logging
+
+    logger = logging.getLogger("nexgen.EDtools.Singla")
+    logger.setLevel(logging.DEBUG)
+
+    if SinglaMaster.isDectrisSingla(master) is False:
+        logger.warning(f"The file {master} is the wrong format.")
+        return
+
+    with h5py.File(master, "r") as fh:
+        singla = SinglaMaster(fh)
+        return singla.get_data_collection_date()
+
+
 def extract_from_SINGLA_master(master: Path | str) -> Dict[str, Any]:
     """
     Extracts mask, flatfield and any other information relative to the detector \
@@ -193,7 +217,6 @@ def extract_from_SINGLA_master(master: Path | str) -> Dict[str, Any]:
         D["detector_number"] = singla.get_detector_number()
         D["detector_readout_time"] = singla.get_detector_readout_time()
         D["photon_energy"] = singla.get_photon_energy()
-        D["data_collection_date"] = singla.get_data_collection_date()
 
     return D
 

--- a/src/nexgen/tools/ED_tools.py
+++ b/src/nexgen/tools/ED_tools.py
@@ -157,7 +157,7 @@ class SinglaMaster:
 
 def extract_start_time_from_master(master: Path | str) -> datetime:
     """
-    Extracts `data_collection_data` from the master file
+    Extracts `data_collection_date` from the master file
 
     Args:
         master (Path | str): Path to Singla master file.
@@ -170,13 +170,18 @@ def extract_start_time_from_master(master: Path | str) -> datetime:
     logger = logging.getLogger("nexgen.EDtools.Singla")
     logger.setLevel(logging.DEBUG)
 
+
     if SinglaMaster.isDectrisSingla(master) is False:
         logger.warning(f"The file {master} is the wrong format.")
         return
 
+    start_time = None
+
     with h5py.File(master, "r") as fh:
         singla = SinglaMaster(fh)
-        return singla.get_data_collection_date()
+        start_time = singla.get_data_collection_date()
+    
+    return start_time
 
 
 def extract_from_SINGLA_master(master: Path | str) -> Dict[str, Any]:


### PR DESCRIPTION
Hello,

I hope this resolves the issue. I've added a function `get_data_collection_date` to `SinglaMaster` class. I then read the date into the dictionary in `extract_from_Singla_master`. It seems that this function is more related to detector parameters so I don't know should the collection date go there. 

The date and time are saved in `params.start_time`. I am assuming the start time from the command line goes to this variable. So, if there is no `start_time`, the script will get that data from the master file. In the end, I pass the `params.start_time` as an argument to the writer function.

I checked this and it works when converting original master and data files on my laptop.