### PR TITLE
Add optional axis fields for tristan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 - Bug when updating goniometer axes from reverse rotation scan: in this case, it changed the increment to positive leading to
 the wrong value for `axis_end` in NXsample.  
+- Added missing `axis_end` and `axis_increment_set` to CopyTristanNexus for multiple binned images.
 
 
 ## 0.8.0

--- a/src/nexgen/nxs_copy/CopyTristanNexus.py
+++ b/src/nexgen/nxs_copy/CopyTristanNexus.py
@@ -186,7 +186,7 @@ def multiple_images_nexus(
                 nxdata[ax].attrs.create(key, value)
             # Now fix all other instances of scan_axis in the tree
             nxsample = nxentry["sample"]
-            convert_scan_axis(nxsample, nxdata, ax)
+            convert_scan_axis(nxsample, nxdata, ax, ax_range)
 
     return nxs_filename.as_posix()
 

--- a/src/nexgen/nxs_copy/copy_utils.py
+++ b/src/nexgen/nxs_copy/copy_utils.py
@@ -120,7 +120,9 @@ def identify_tristan_scan_axis(nxs_in: h5py.File) -> Tuple[str | None, Dict[str,
     return None, {}
 
 
-def convert_scan_axis(nxsample: h5py.Group, nxdata: h5py.Group, ax: str):
+def convert_scan_axis(
+    nxsample: h5py.Group, nxdata: h5py.Group, ax: str, ax_range: ArrayLike | None = None
+):
     """
     Modify all instances of scan_axis present in NeXus file NXsample group.
 
@@ -128,6 +130,8 @@ def convert_scan_axis(nxsample: h5py.Group, nxdata: h5py.Group, ax: str):
         nxsample (h5py.Group): NXsample group of NeXus file to be modified.
         nxdata (h5py.Group): NXdata group of NeXus file to be modified.
         ax (str): Name of scan_axis.
+        ax_range (ArrayLike): Scan points. If passed, axis_increment_set and axis_end will also be written.\
+            Defaults to None
     """
     del nxsample["transformations/" + ax]
     nxsample["transformations/" + ax] = nxdata[ax]
@@ -136,6 +140,10 @@ def convert_scan_axis(nxsample: h5py.Group, nxdata: h5py.Group, ax: str):
     )
     del nxsample[name]
     nxsample[name] = nxdata[ax]
+    if ax_range is not None and "sam" not in ax:
+        increment = round(ax_range[1] - ax_range[0], 3)
+        nxsample["sample_" + ax].create_dataset(ax + "_increment_set", data=increment)
+        nxsample["sample_" + ax].create_dataset(ax + "_end", data=ax_range + increment)
 
 
 def check_and_fix_det_axis(nxs_in: h5py.File):

--- a/tests/nxs_copy/test_copy_tools.py
+++ b/tests/nxs_copy/test_copy_tools.py
@@ -60,8 +60,15 @@ def test_convert_scan_axis(dummy_nexus_file):
     nxsample["sample_omega"].create_dataset("omega", data=(0, 2))
     nxtr["omega"] = nxsample["sample_omega/omega"]
 
-    convert_scan_axis(nxsample, nxdata, "omega")
+    convert_scan_axis(nxsample, nxdata, "omega", scan_range)
     assert_array_equal(nxsample["sample_omega/omega"], scan_range)
+    assert_array_equal(nxtr["omega"], scan_range)
+    assert (
+        "omega_end" in nxsample["sample_omega"].keys()
+        and "omega_increment_set" in nxsample["sample_omega"].keys()
+    )
+    assert_array_equal(nxsample["sample_omega/omega_increment_set"][()], 0.2)
+    assert_array_equal(nxsample["sample_omega/omega_end"][()], scan_range + 0.2)
 
 
 def test_check_and_fix_det_z(dummy_nexus_file):


### PR DESCRIPTION
Fixes #170 

Writes the optional axes fields `axis_increment_set` and `axis_end` for tristan binned data.