### PR TITLE
Fix rotation axis vector for electron diffraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 
 
+## 0.#.#
+
+### Fixed
+- Rotation axis vector for Electron Diffraction.
+
+
 ## 0.8.4
 
 ### Added

--- a/src/nexgen/beamlines/ED_params.py
+++ b/src/nexgen/beamlines/ED_params.py
@@ -8,7 +8,7 @@ from .beamline_utils import BeamlineAxes
 
 EDSingla = BeamlineAxes(
     gonio=[
-        Axis("alpha", ".", TransformationType.ROTATION, Point3D(-1, 0, 0)),
+        Axis("alpha", ".", TransformationType.ROTATION, Point3D(0, -1, 0)),
         Axis("sam_z", "alpha", TransformationType.TRANSLATION, Point3D(0, 0, 1)),
         Axis("sam_y", "sam_z", TransformationType.TRANSLATION, Point3D(0, 1, 0)),
         Axis("sam_x", "sam_y", TransformationType.TRANSLATION, Point3D(1, 0, 0)),


### PR DESCRIPTION
In the beamline parameters for electron diffraction, the rotation axis vector is wrong. 
This value should be `0,-1,0`