### PR TITLE
Disable detectorSpecific fields

### DIFF
--- a/src/nexgen/nxs_utils/detector.py
+++ b/src/nexgen/nxs_utils/detector.py
@@ -29,7 +29,11 @@ EIGER_CONST = {
     "photon_energy": "_dectris/photon_energy",
     "software_version": "_dectris/software_version",
     "ntrigger": "/_dectris/ntrigger",
+    # "serial_number": "/_dectris/detector_number",
+    # "eiger_fw_version": "/_dectris/eiger_fw_version",
+    # "data_collection_date": "/_dectris/data_collection_date",
 }
+# TODO see https://github.com/DiamondLightSource/nexgen/issues/236
 
 TRISTAN_CONST = {
     "flatfield": "Tristan10M_flat_field_coeff_with_Mo_17.479keV.h5",

--- a/src/nexgen/nxs_utils/detector.py
+++ b/src/nexgen/nxs_utils/detector.py
@@ -26,8 +26,9 @@ EIGER_CONST = {
     "bit_depth_image": "_dectris/bit_depth_image",
     "detector_readout_time": "_dectris/detector_readout_time",
     "threshold_energy": "_dectris/threshold_energy",
+    "photon_energy": "_dectris/photon_energy",
     "software_version": "_dectris/software_version",
-    "serial_number": "_dectris/detector_number",
+    "ntrigger": "/_dectris/ntrigger",
 }
 
 TRISTAN_CONST = {

--- a/src/nexgen/nxs_write/nxclass_writers.py
+++ b/src/nexgen/nxs_write/nxclass_writers.py
@@ -491,12 +491,14 @@ def write_NXdetector(
                 if k in [
                     "software_version",
                     "ntrigger",
+                    "data_collection_date",
                     "eiger_fw_version",
                     "serial_number",
                 ]:
-                    # NOTE: Software version & ntrigger should go in detectorSpecific (NXcollection)
-                    # eiger_fw_version and serial_number as they are in the meta file will
-                    # kill processing.
+                    # NOTE: Software version, eiger_fw_version ntrigger & date should
+                    # go in detectorSpecific (NXcollection)
+                    # TODO re-enable eiger_fw_version, date & serial_number
+                    # see https://github.com/DiamondLightSource/nexgen/issues/236
                     continue
                 nxdetector[k] = h5py.ExternalLink(meta_link, v)
         else:
@@ -841,9 +843,9 @@ def write_NXcollection(
                 data=np.string_(detector_params.constants["software_version"]),
             )
     if "EIGER" in detector_params.description.upper() and meta:
-        grp["ntrigger"] = h5py.ExternalLink(
-            meta.name, detector_params.constants["ntrigger"]
-        )
+        for field in ["ntrigger"]:  # "data_collection_date", "eiger_fw_version"]
+            # TODO See https://github.com/DiamondLightSource/nexgen/issues/236
+            grp[field] = h5py.ExternalLink(meta.name, detector_params.constants[field])
     elif "TRISTAN" in detector_params.description.upper():
         tick = ureg.Quantity(detector_params.constants["detector_tick"])
         grp.create_dataset("detector_tick", data=tick.magnitude)

--- a/src/nexgen/nxs_write/nxmx_writer.py
+++ b/src/nexgen/nxs_write/nxmx_writer.py
@@ -17,6 +17,7 @@ from numpy.typing import DTypeLike
 from ..nxs_utils.detector import Detector
 from ..nxs_utils.goniometer import Goniometer
 from ..nxs_utils.source import Attenuator, Beam, Source
+from ..tools.metafile import DectrisMetafile
 from ..tools.vds_tools import (
     clean_unused_links,
     image_vds_writer,
@@ -121,12 +122,38 @@ class NXmxFileWriter:
             write_NXdatetime(nxs, timestamp, dset_name)
         nxmx_logger.info(f"{dset_name} timestamp for collection updated.")
 
+    def update_detectorSpec(self, image_filename: str | None = None):
+        """"Update the nexus file post-collection with detector specific fields \
+        that need to be read and copied from the meta file.
+
+        Args:
+            image_filename (str | None, optional): Filename stem to use to look for image files. \
+                Needed in case it doesn't match the NeXus file name. Format: filename_runnumber. \
+                Defaults to None.
+        """
+        metafile = self._get_meta_file(image_filename)
+        with h5py.File(metafile, "r", libver="latest", swmr=True) as fh:
+            serial_number = DectrisMetafile(fh).get_serial_number()
+            fw_version = DectrisMetafile(fh).get_fw_version()
+            date = DectrisMetafile(fh).get_data_collection_date()
+        with h5py.File(self.filename, "r+") as nxs:
+            nxdet = nxs["/entry/instrument/detector"]
+            nxdet.create_dataset("serial_number", data=np.string_(serial_number))
+            nxspec = nxdet["detectorSpecific"]
+            nxspec.create_dataset("eiger_fw_version", data=np.string_(fw_version))
+            nxspec.create_dataset("data_collection_date", data=np.string_(date))
+        nxmx_logger.info(
+            "Nexus file updated with data_collection_date, eiger_fw_version and serial_number"
+        )
+
     def add_NXnote(self, notes: Dict, loc: str = "/entry/notes"):
         """Save any additional information as NXnote at the end of the collection.
 
         Args:
-            notes (Dict): Dictionary of (key, value) pairs where key represents the dataset name and value its data.
-            loc (str, optional): Location in the NeXus file to save metadata. Defaults to "/entry/notes".
+            notes (Dict): Dictionary of (key, value) pairs where key represents the \
+                dataset name and value its data.
+            loc (str, optional): Location in the NeXus file to save metadata. \
+                Defaults to "/entry/notes".
         """
         with h5py.File(self.filename, "r+") as nxs:
             write_NXnote(nxs, loc, notes)
@@ -145,16 +172,18 @@ class NXmxFileWriter:
         This function calls the writers for the main NXclass objects.
 
         Args:
-            image_datafiles (List | None, optional): List of image data files. If not passed, the program will look for \
-                files with the stem_######.h5 in the target directory. Defaults to None.
-            image_filename (str | None, optional): Filename stem to use to look for image files. Needed in case it doesn't match \
-                the NeXus file name. Format: filename_runnumber. Defaults to None.
-            start_time (datetime | str, optional): Collection start time if available, in the format "%Y-%m-%dT%H:%M:%SZ".\
+            image_datafiles (List | None, optional): List of image data files. If not passed, \
+                the program will look for files with the stem_######.h5 in the target directory. \
                 Defaults to None.
-            est_end_time (datetime | str, optional): Collection estimated end time if available, in the format "%Y-%m-%dT%H:%M:%SZ".\
+            image_filename (str | None, optional): Filename stem to use to look for image files. \
+                Needed in case it doesn't match the NeXus file name. Format: filename_runnumber. \
                 Defaults to None.
-            write_mode (str, optional): String indicating writing mode for the output NeXus file. Accepts any valid \
-                h5py file opening mode. Defaults to "x".
+            start_time (datetime | str, optional): Collection start time if available, in the \
+                format "%Y-%m-%dT%H:%M:%SZ".Defaults to None.
+            est_end_time (datetime | str, optional): Collection estimated end time if available, \
+                in the format "%Y-%m-%dT%H:%M:%SZ". Defaults to None.
+            write_mode (str, optional): String indicating writing mode for the output NeXus file. \
+                Accepts any valid h5py file opening mode. Defaults to "x".
         """
         metafile = self._get_meta_file(image_filename)
         if metafile:

--- a/src/nexgen/tools/metafile.py
+++ b/src/nexgen/tools/metafile.py
@@ -159,8 +159,45 @@ class DectrisMetafile(Metafile):
             self.__getitem__(_loc_thickness[0])[0],
         )
 
-    def get_bit_depth_image(self):
+    def get_bit_depth_image(self) -> int:
         _loc = [obj for obj in self.walk if "bit_depth_image" in obj]
+        if len(_loc) == 0:
+            return None
+        return self.__getitem__(_loc[0])[0]
+
+    def get_data_collection_date(self) -> str:
+        if self.hasDectrisGroup:
+            config = self.read_dectris_config()
+            return config["data_collection_date"]
+        if self.hasConfig:
+            config = self.read_config_dset()
+            return config["data_collection_date"]
+        _loc = [obj for obj in self.walk if "data_collection_date" in obj]
+        if len(_loc) == 0:
+            return None
+        return self.__getitem__(_loc[0])[0]
+
+    def get_fw_version(self) -> str:
+        if self.hasDectrisGroup:
+            config = self.read_dectris_config()
+            return config["eiger_fw_version"]
+        if self.hasConfig:
+            config = self.read_config_dset()
+            return config["eiger_fw_version"]
+        _loc = [obj for obj in self.walk if "eiger_fw_version" in obj]
+        if len(_loc) == 0:
+            return None
+        return self.__getitem__(_loc[0])[0]
+
+    def get_serial_number(self) -> str:
+        # Stored in meta file as "detector_number"
+        if self.hasDectrisGroup:
+            config = self.read_dectris_config()
+            return config["detector_number"]
+        if self.hasConfig:
+            config = self.read_config_dset()
+            return config["detector_number"]
+        _loc = [obj for obj in self.walk if "detector_number" in obj]
         if len(_loc) == 0:
             return None
         return self.__getitem__(_loc[0])[0]


### PR DESCRIPTION
`serial_number`, `eiger_fw_version`, and `data_collection_date` external links not currently written because the date type in the meta file will cause autoPROC to fail.

Will need [Odin fix ](https://github.com/dls-controls/ADOdin/issues/21)before being re-enabled.