### PR TITLE
Make logs less chatty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Changed
 - Non-standard "sample_{phi,omega,...}" groups in NXsample made optional and NXclass now set to NXtransformations instead of NXpositioner.
+- Set level of most logs in the NXclass and Nexus writers to DEBUG.
+- Console logs level set to INFO, DEBUG logs only written to file.
 
 
 ## 0.9.2

--- a/src/nexgen/__main__.py
+++ b/src/nexgen/__main__.py
@@ -5,6 +5,6 @@ def main(args=None):
     version_parser.parse_args(args)
 
 
-# Test with python -m nexgen
+# Test with python -m nexgen -V
 if __name__ == "__main__":
     main()

--- a/src/nexgen/log.py
+++ b/src/nexgen/log.py
@@ -21,7 +21,7 @@ logging_config = {
     },
     "handlers": {
         "console": {
-            "level": "DEBUG",
+            "level": "INFO",
             "class": "logging.StreamHandler",
             "formatter": "default",
             "stream": "ext://sys.stdout",

--- a/src/nexgen/nxs_copy/copy_nexus.py
+++ b/src/nexgen/nxs_copy/copy_nexus.py
@@ -40,10 +40,8 @@ def images_nexus(
     data_file = [Path(d).expanduser().resolve() for d in data_file]
     original_nexus = Path(original_nexus).expanduser().resolve()
     nxs_filename = get_nexus_filename(data_file[0], copy=True)
-    copy_logger.info(f"New NeXus file name: {nxs_filename}")
-    with h5py.File(original_nexus, "r") as nxs_in, h5py.File(
-        nxs_filename, "x"
-    ) as nxs_out:
+    copy_logger.debug(f"New NeXus file name: {nxs_filename}")
+    with h5py.File(original_nexus, "r") as nxs_in, h5py.File(nxs_filename, "x") as nxs_out:
         if simple_copy is True:
             # Copy the whole tree
             get_nexus_tree(nxs_in, nxs_out, skip=False)
@@ -54,7 +52,7 @@ def images_nexus(
             nxs_out.attrs["default"] = "entry"
             # Copy the whole tree except for nxdata and whatever other group was passed.
             nxentry = get_nexus_tree(nxs_in, nxs_out, skip=True, skip_obj=skip_group)
-            copy_logger.info(f"Re write NXdata with link to {data_file[0]}.")
+            copy_logger.debug(f"Re write NXdata with link to {data_file[0]}.")
             if "NXdata" in skip_group:  # it always is...
                 # Create nxdata group
                 nxdata = nxentry.create_group("data")
@@ -93,7 +91,7 @@ def pseudo_events_nexus(
     data_file = [Path(d).expanduser().resolve() for d in data_file]
     original_nexus = Path(original_nexus).expanduser().resolve()
     nxs_filename = get_nexus_filename(data_file[0], copy=True)
-    copy_logger.info(f"New NeXus file name: {nxs_filename}")
+    copy_logger.debug(f"New NeXus file name: {nxs_filename}")
     with h5py.File(original_nexus, "r") as nxs_in, h5py.File(
         nxs_filename, "x"
     ) as nxs_out:

--- a/src/nexgen/nxs_write/nxclass_writers.py
+++ b/src/nexgen/nxs_write/nxclass_writers.py
@@ -92,7 +92,7 @@ def write_NXdata(
         OSError: If no data is passed.
         ValueError: If the data type is neither "images" nor "events".
     """
-    NXclass_logger.info("Start writing NXdata.")
+    NXclass_logger.debug("Start writing NXdata.")
     # Check that a valid datafile_list has been passed.
     if len(datafiles) == 0:
         raise OSError(
@@ -231,7 +231,7 @@ def write_NXsample(
         add_nonstandard_fields (bool, optional): Choose whether to add the old "sample_{x,phi,...}/{x,phi,...}" to the group. \
             These fields are non-standard but may be needed for processing to run. Defaults to True.
     """
-    NXclass_logger.info("Start writing NXsample.")
+    NXclass_logger.debug("Start writing NXsample.")
     # Create NXsample group, unless it already exists, in which case just open it.
     nxsample = nxsfile.require_group("/entry/sample")
     create_attributes(
@@ -304,7 +304,7 @@ def write_NXinstrument(
         reset_instrument_name (bool, optional): If True, a string with the name of the \
             instrument used. Otherwise, it will be set to 'DIAMOND BEAMLINE Ixx'. Defaults to False.
     """
-    NXclass_logger.info("Start writing NXinstrument.")
+    NXclass_logger.debug("Start writing NXinstrument.")
     # Create NXinstrument group, unless it already exists, in which case just open it.
     nxinstrument = nxsfile.require_group("/entry/instrument")
     create_attributes(
@@ -314,7 +314,7 @@ def write_NXinstrument(
     )
 
     # Write /name field and relative attribute
-    NXclass_logger.info(f"{source.short_name} {source.beamline}")
+    NXclass_logger.debug(f"{source.short_name} {source.beamline}")
     name_str = (
         source.set_instrument_name()
         if reset_instrument_name
@@ -327,7 +327,7 @@ def write_NXinstrument(
         (f"{source.short_name} {source.beamline}",),
     )
 
-    NXclass_logger.info("Write NXattenuator and NXbeam.")
+    NXclass_logger.debug("Write NXattenuator and NXbeam.")
     # Write NXattenuator group: entry/instrument/attenuator
     nxatt = nxinstrument.require_group("attenuator")
     create_attributes(nxatt, ("NX_class",), ("NXattenuator",))
@@ -356,7 +356,7 @@ def write_NXsource(nxsfile: h5py.File, source: Source):
         nxsfile (h5py.File): NeXus file handle.
         source (Source): Source definition, containing the facility information.
     """
-    NXclass_logger.info("Start writing NXsource.")
+    NXclass_logger.debug("Start writing NXsource.")
     nxsource = nxsfile.require_group("/entry/source")
     create_attributes(
         nxsource,
@@ -387,7 +387,7 @@ def write_NXdetector(
         num_images (int, optional): Total number of images in collections. Defaults to None
         meta (Path, optional): Path to _meta.h5 file. Defaults to None.
     """
-    NXclass_logger.info("Start writing NXdetector.")
+    NXclass_logger.debug("Start writing NXdetector.")
     # Create NXdetector group, unless it already exists, in which case just open it.
     nxdetector = nxsfile.require_group("/entry/instrument/detector")
     create_attributes(
@@ -409,7 +409,7 @@ def write_NXdetector(
     # If there is a meta file, a lot of information will be linked instead of copied
     if isinstance(detector.detector_params, EigerDetector):
         if meta:
-            NXclass_logger.info(f"Found metadata in {meta.as_posix()} file.")
+            NXclass_logger.debug(f"Found metadata in {meta.as_posix()} file.")
             meta_link = (
                 meta.name
                 if meta.parent == Path(nxsfile.filename).parent
@@ -432,7 +432,7 @@ def write_NXdetector(
         else:
             NXclass_logger.warning(
                 """
-                Meta file for Eiger detector hasn't been specified.
+                Meta file for Eiger detector hasn't been specified or found.
                 No links will be written. Pixel mask and flatfield information missing.
                 """
             )
@@ -585,7 +585,7 @@ def write_NXdetector_module(
         pixel_size (List | Tuple): Size of the single pixels in fast and slow direction, in mm.
         beam_center (Optional[List | Tuple], optional): Beam center position, needed only if origin needs to be calculated. Defaults to None.
     """
-    NXclass_logger.info("Start writing NXdetector_module.")
+    NXclass_logger.debug("Start writing NXdetector_module.")
     # Create NXdetector_module group, unless it already exists, in which case just open it.
     nxmodule = nxsfile.require_group("/entry/instrument/detector/module")
     create_attributes(
@@ -717,7 +717,7 @@ def write_NXcollection(
         num_images (int, optional): Total number of images collected. Defaults to None.
         meta (Path, optional): Path to _meta.h5 file. Defaults to None.
     """
-    NXclass_logger.info("Start writing detectorSpecific group as NXcollection.")
+    NXclass_logger.debug("Start writing detectorSpecific group as NXcollection.")
     # Create detectorSpecific group
     grp = nxdetector.require_group("detectorSpecific")
     grp.create_dataset(
@@ -812,7 +812,7 @@ def write_NXnote(nxsfile: h5py.File, loc: str, info: Dict):
         loc (str): Location inside the NeXus file to write NXnote group.
         info (Dict): Dictionary of datasets to be written to NXnote.
     """
-    NXclass_logger.info("Start writing NXnote.")
+    NXclass_logger.debug("Start writing NXnote.")
     # Create the NXnote group in the specified location
     nxnote = nxsfile.require_group(loc)
     create_attributes(
@@ -827,7 +827,7 @@ def write_NXnote(nxsfile: h5py.File, loc: str, info: Dict):
             if isinstance(v, str):
                 v = np.string_(v)
             nxnote.create_dataset(k, data=v)
-            NXclass_logger.info(f"{k} dataset written in {loc}.")
+            NXclass_logger.debug(f"{k} dataset written in {loc}.")
 
 
 def write_NXcoordinate_system_set(
@@ -876,7 +876,7 @@ def write_NXcoordinate_system_set(
     transf.create_dataset("origin", data=origin)
 
     # Base vectors
-    NXclass_logger.info(
+    NXclass_logger.debug(
         "Base vectors: \n"
         f"x: {base_vectors['x'].vector} \n"
         f"y: {base_vectors['y'].vector} \n"

--- a/src/nexgen/nxs_write/nxmx_writer.py
+++ b/src/nexgen/nxs_write/nxmx_writer.py
@@ -132,7 +132,7 @@ class NXmxFileWriter:
         """
         with h5py.File(self.filename, "r+") as nxs:
             write_NXnote(nxs, loc, notes)
-        nxmx_logger.info(f"Notes saved in {loc}.")
+        nxmx_logger.debug(f"Notes saved in {loc}.")
 
     def write(
         self,
@@ -273,7 +273,7 @@ class NXmxFileWriter:
                     Resetting it to match the number of frames indicated by the scan."
                 )
 
-        nxmx_logger.info(f"VDS shape set to {vds_shape}.")
+        nxmx_logger.debug(f"VDS shape set to {vds_shape}.")
 
         with h5py.File(self.filename, "r+") as nxs:
             if "jungfrau" in self.detector.detector_params.description.lower():
@@ -591,7 +591,7 @@ class EDNXmxFileWriter(NXmxFileWriter):
         """
         with h5py.File(self.filename, "r+") as nxs:
             if writer_type == "dataset":
-                nxmx_logger.info(
+                nxmx_logger.debug(
                     "Writing vds dataset as /entry/data/data in nexus file."
                 )
                 image_vds_writer(

--- a/src/nexgen/nxs_write/write_utils.py
+++ b/src/nexgen/nxs_write/write_utils.py
@@ -89,11 +89,11 @@ def calculate_origin(
         fast_axis_vector (Tuple): Fast axis vector.
         slow_axis_vector (Tuple): Slow axis vector.
         mode (str, optional): Decide how origin should be calculated.
-                            If set to "1" the displacement vector is un-normalized \
-                                and the offset value set to 1.0.
-                            If set to "2" the displacement is normalized and the \
-                                offset value is set to the magnitude of the displacement.
-                            Defaults to "1".
+            If set to "1" the displacement vector is un-normalized \
+                and the offset value set to 1.0.
+            If set to "2" the displacement is normalized and the \
+                offset value is set to the magnitude of the displacement.
+            Defaults to "1".
 
     Returns:
         det_origin (List): Displacement of beam center, vector attribute of module_offset.
@@ -218,12 +218,14 @@ def mask_and_flatfield_writer_for_event_data(
         return
 
     nxdet_grp.create_dataset(f"{dset_name}_applied", data=applied_val)
-    NXclassUtils_logger.info(f"Looking for file {dset_data_file} in {wdir.as_posix()}.")
+    NXclassUtils_logger.debug(
+        f"Looking for file {dset_data_file} in {wdir.as_posix()}."
+    )
     filename = [
         wdir / dset_data_file for f in wdir.iterdir() if dset_data_file == f.name
     ]
     if filename:
-        NXclassUtils_logger.info(f"File {dset_name} found in working directory.")
+        NXclassUtils_logger.debug(f"File {dset_name} found in working directory.")
         write_compressed_copy(
             nxdet_grp,
             dset_name,
@@ -288,6 +290,7 @@ def write_compressed_copy(
             "The dset and filename arguments are mutually exclusive."
             "Please pass only the one from which the data should be copied."
         )
+
     if filename and not dset_key:
         NXclassUtils_logger.warning(
             f"Missing key to find the dataset to be copied inside {filename}. {dset_name} will not be written into the NeXus file."

--- a/src/nexgen/tools/meta_reader.py
+++ b/src/nexgen/tools/meta_reader.py
@@ -37,7 +37,7 @@ def overwrite_beam(meta_file: h5py.File, name: str, beam: Dict | ScopeExtract):
         meta = DectrisMetafile(meta_file)
         wl = meta.get_wavelength()
         if wl is None:
-            overwrite_logger.info("No wavelength information found in meta file.")
+            overwrite_logger.warning("No wavelength information found in meta file.")
             return
     else:
         raise ValueError("Unknown detector: please pass a valid detector description.")
@@ -90,14 +90,14 @@ def overwrite_detector(
         meta = DectrisMetafile(meta_file)
         overwrite_logger.info("Looking through meta file for Eiger detector.")
         if meta.hasMask is True:
-            overwrite_logger.info("Mask has been located in meta file")
+            overwrite_logger.debug("Mask has been located in meta file")
             mask_info = meta.find_mask()
             new_values["pixel_mask"] = mask_info[0]
             new_values["pixel_mask_applied"] = mask_info[1]
             link_list[0].append("pixel_mask")
             link_list[0].append("pixel_mask_applied")
         if meta.hasFlatfield is True:
-            overwrite_logger.info("Flatfield has been located in meta file")
+            overwrite_logger.debug("Flatfield has been located in meta file")
             flatfield_info = meta.find_flatfield()
             new_values["flatfield"] = flatfield_info[0]
             new_values["flatfield_applied"] = flatfield_info[1]
@@ -120,29 +120,29 @@ def overwrite_detector(
                 units_of_length(pix[1]),
             ]
             overwrite_logger.warning("Pixel_size will be overwritten.")
-            overwrite_logger.info(
+            overwrite_logger.debug(
                 f"Values for x and y pixel size found in meta file: {pix[0]}, {pix[1]}"
             )
             new_values["beam_center"] = meta.get_beam_center()
             overwrite_logger.warning("Beam_center will be overwritten.")
-            overwrite_logger.info(
+            overwrite_logger.debug(
                 f"Values for x and y beam center position found in meta file: "
                 f"{new_values['beam_center']}"
             )
             sensor_info = meta.get_sensor_information()
             new_values["sensor_material"] = sensor_info[0]
             overwrite_logger.warning("Sensor material will be overwritten.")
-            overwrite_logger.info(
+            overwrite_logger.debug(
                 f"Value for sensor material found in meta file: {sensor_info[0]}"
             )
             new_values["sensor_thickness"] = units_of_length(sensor_info[1])
             overwrite_logger.warning("Sensor thickness will be overwritten.")
-            overwrite_logger.info(
+            overwrite_logger.debug(
                 f"Value for sensor thickness found in meta file: {sensor_info[1]}"
             )
             new_values["overload"] = meta.get_saturation_value()
             overwrite_logger.warning("Saturation value (overload) will be overwritten.")
-            overwrite_logger.info(
+            overwrite_logger.debug(
                 f"Value for overload found in meta file: {new_values['overload']}"
             )
     else:
@@ -177,11 +177,11 @@ def define_vds_data_type(meta_file: DectrisMetafile) -> DTypeLike:
     Returns:
         DTypeLike: Data type as np.uint##.
     """
-    overwrite_logger.info("Define dtype for VDS creating from bit_depth_image.")
+    overwrite_logger.debug("Define dtype for VDS creating from bit_depth_image.")
     # meta = DectrisMetafile(meta_file)
 
     nbits = meta_file.get_bit_depth_image()
-    overwrite_logger.info(f"Found value for bit_depth_image: {nbits}.")
+    overwrite_logger.debug(f"Found value for bit_depth_image: {nbits}.")
     if nbits == 32:
         return np.uint32
     elif nbits == 8:
@@ -206,7 +206,7 @@ def update_axes_from_meta(
         use_config (bool, optional): If passed read from config dataset in meta file instead of _dectris\
             group. Defaults to False.
     """
-    overwrite_logger.info("Updating axes list with values saved to _dectris group.")
+    overwrite_logger.debug("Updating axes list with values saved to _dectris group.")
     if meta_file.hasDectrisGroup is False:
         overwrite_logger.warning(
             "No Dectris group in meta file. No values will be updated."
@@ -222,10 +222,10 @@ def update_axes_from_meta(
     for ax in axes_list:
         if f"{ax.name}_start" in config.keys():
             ax.start_pos = config[f"{ax.name}_start"]
-            overwrite_logger.info(f"Start value for axis {ax.name}: {ax.start_pos}.")
+            overwrite_logger.debug(f"Start value for axis {ax.name}: {ax.start_pos}.")
             if f"{ax.name}_increment" in config.keys():
                 ax.increment = config[f"{ax.name}_increment"]
-                overwrite_logger.info(
+                overwrite_logger.debug(
                     f"Increment value for axis {ax.name}: {ax.increment}."
                 )
         if osc_axis and ax.name == osc_axis:
@@ -234,4 +234,4 @@ def update_axes_from_meta(
         if ax.name == "det_z":
             dist = units_of_length(meta_file.get_detector_distance())
             ax.start_pos = dist.to("mm").magnitude
-            overwrite_logger.info(f"Start value for axis {ax.name}: {ax.start_pos}.")
+            overwrite_logger.debug(f"Start value for axis {ax.name}: {ax.start_pos}.")

--- a/src/nexgen/tools/vds_tools.py
+++ b/src/nexgen/tools/vds_tools.py
@@ -130,7 +130,7 @@ def split_datasets(
         vds_logger.warning("VDS start index not passed as int, will attempt to cast")
 
     if vds_shape is None:
-        vds_logger.info(
+        vds_logger.debug(
             "VDS shape not chosen, it will be calculated from the full data shape and the chosen start index."
         )
         vds_shape = (data_shape[0] - start_idx, *data_shape[1:])
@@ -211,7 +211,7 @@ def image_vds_writer(
         data_type (DTypeLike, optional): The type of the input data. Defaults to np.uint16.
         entry_key (str, optional): Entry key for the Virtual DataSet name. Defaults to data.
     """
-    vds_logger.info("Start creating VDS ...")
+    vds_logger.debug("Start creating VDS ...")
     # Where the vds will go
     nxdata = nxsfile["/entry/data"]
     dset_names = find_datasets_in_file(nxdata)
@@ -241,7 +241,7 @@ def image_vds_writer(
 
     # Writea Virtual Dataset in NeXus file
     nxdata.create_virtual_dataset(entry_key, layout, fillvalue=-1)
-    vds_logger.info("VDS written to NeXus file.")
+    vds_logger.debug("VDS correctly written to NeXus file.")
 
 
 def jungfrau_vds_writer(
@@ -295,7 +295,7 @@ def vds_file_writer(
         data_type (DTypeLike, optional): Dtype. Defaults to np.uint16.
         entry_key (str): Entry key for the Virtual DataSet name. Defaults to data.
     """
-    vds_logger.info("Start creating VDS ...")
+    vds_logger.debug("Start creating VDS file ...")
     # Where the vds will go
     nxdata = nxsfile["/entry/data"]
     # entry_key = "data"
@@ -323,7 +323,7 @@ def vds_file_writer(
     with h5py.File(vds_filename, "w") as vds:
         vds.create_virtual_dataset("data", layout, fillvalue=-1)
     nxdata["data"] = h5py.ExternalLink(vds_filename.name, "data")
-    vds_logger.info(f"{vds_filename} written and link added to NeXus file.")
+    vds_logger.debug(f"{vds_filename} written and link added to NeXus file.")
 
 
 def clean_unused_links(
@@ -339,25 +339,25 @@ def clean_unused_links(
         vds_shape (Tuple | List): Actual shape of the VDS dataset, usually defined as (num_frames, *image_size).
         start_index(int): The start point for the source data. Defaults to 0.
     """
-    vds_logger.info("Cleaning links unused in VDS ...")
+    vds_logger.debug("Cleaning links unused in VDS ...")
     # Location of the VDS
     nxdata = nxsfile["/entry/data"]
     dataset_names = find_datasets_in_file(nxdata)
     if len(dataset_names) == 1:
-        vds_logger.info("Only one linked file, no need to remove it.")
+        vds_logger.debug("Only one linked file, no need to remove it.")
         return
     datasets = [nxdata[name] for name in dataset_names]
     dataset_lengths = [d.shape[0] for d in datasets]
     if sum(dataset_lengths) == vds_shape[0]:
-        vds_logger.info("All links are used in VDS, no need to remove any.")
+        vds_logger.debug("All links are used in VDS, no need to remove any.")
         return
     for i, _ in enumerate(datasets):
         # unlink datasets before the start of VDS
         if sum(dataset_lengths[0 : i + 1]) < start_index:
-            vds_logger.info(f"Removing {dataset_names[i]} link.")
+            vds_logger.debug(f"Removing {dataset_names[i]} link.")
             del nxdata[dataset_names[i]]
         # unlink datasets after the end of VDS
         if sum(dataset_lengths[0:i]) > start_index + vds_shape[0]:
-            vds_logger.info(f"Removing {dataset_names[i]} link.")
+            vds_logger.debug(f"Removing {dataset_names[i]} link.")
             del nxdata[dataset_names[i]]
-    vds_logger.info("Links unused in VDS removed from NeXus file.")
+    vds_logger.debug("Links unused in VDS removed from NeXus file.")

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -15,7 +15,7 @@ def dummy_logger():
 def test_basic_logging_config(dummy_logger):
     assert dummy_logger.hasHandlers() is True
     assert len(dummy_logger.handlers) == 1
-    assert dummy_logger.handlers[0].level == logging.DEBUG
+    assert dummy_logger.handlers[0].level == logging.INFO
 
 
 def test_logging_config_with_filehandler(dummy_logger):


### PR DESCRIPTION
Closes #194 

- Sets the logging level for the StreamHandler to INFO
- Sends all debug messages only to the file, when configured.
- Sets logs from NXclass writers/ Nexus writer to DEBUG to avoid overly chatty logs.