### PR TITLE
Make code compatible with both numpy 2.0 and earlier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG
 
 
+## #.#.#
+
+### Fixed
+- Numpy2.0 compatibility - stop using deprecated np.string_ alias for fixed-width bytestrings.
+
+
+
 ## 0.9.3
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "freephil",
     "h5py",
     "hdf5plugin>=4.0.1",
-    "numpy<2.0",
+    "numpy",
     "pint",
     "importlib_resources>=1.1",
     "scanspec",

--- a/src/nexgen/nxs_copy/copy_utils.py
+++ b/src/nexgen/nxs_copy/copy_utils.py
@@ -18,7 +18,7 @@ from ..nxs_write.write_utils import create_attributes
 from ..utils import units_of_length, walk_nxs
 
 
-def h5str(h5_value: str | np.string_ | bytes) -> str:
+def h5str(h5_value: str | np.bytes_ | bytes) -> str:
     """
     Convert a value returned an h5py attribute to str.
 
@@ -27,12 +27,12 @@ def h5str(h5_value: str | np.string_ | bytes) -> str:
     fixed or variable length. This function collapses the two to str.
 
     Args:
-        h5_value (str | np.string_ | bytes): Original attribute value.
+        h5_value (str | np.bytes_ | bytes): Original attribute value.
 
     Returns:
-        str: Attribute value collapsed to str.
+        str: Attribute value collapsed to a str.
     """
-    if isinstance(h5_value, (np.string_, bytes)):
+    if isinstance(h5_value, (np.bytes_, bytes)):
         return h5_value.decode("utf-8")
     return h5_value
 
@@ -52,7 +52,7 @@ def get_skip_list(nxentry: h5py.Group, skip_obj: List[str]) -> List[str]:
     skip_list = []
     for obj in obj_list:
         try:
-            if nxentry[obj].attrs["NX_class"] in np.string_(skip_obj):
+            if nxentry[obj].attrs["NX_class"] in np.bytes_(skip_obj):
                 skip_list.append(obj)
         except Exception:
             pass
@@ -174,7 +174,7 @@ def check_and_fix_det_axis(nxs_in: h5py.File):
             "distance", data=dist.to("m").magnitude
         )
         nxs_in["/entry/instrument/detector/distance"].attrs.create(
-            "units", np.string_("m")
+            "units", np.bytes_("m")
         )
     else:
         return

--- a/src/nexgen/nxs_write/nxclass_writers.py
+++ b/src/nexgen/nxs_write/nxclass_writers.py
@@ -66,7 +66,7 @@ def write_NXentry(nxsfile: h5py.File, definition: str = "NXmx") -> h5py.Group:
     )
 
     # Application definition: /entry/definition
-    nxentry.create_dataset("definition", data=np.string_(definition))
+    nxentry.create_dataset("definition", data=np.bytes_(definition))
     return nxentry
 
 
@@ -281,7 +281,7 @@ def write_NXsample(
     if sample_details:
         for k, v in sample_details.items():
             if isinstance(v, str):
-                v = np.string_(v)
+                v = np.bytes_(v)
             nxsample.create_dataset(k, data=v)
 
 
@@ -320,7 +320,7 @@ def write_NXinstrument(
         if reset_instrument_name
         else f"DIAMOND BEAMLINE {source.beamline}"
     )
-    nxinstrument.create_dataset("name", data=np.string_(name_str))
+    nxinstrument.create_dataset("name", data=np.bytes_(name_str))
     create_attributes(
         nxinstrument["name"],
         ("short_name",),
@@ -364,11 +364,11 @@ def write_NXsource(nxsfile: h5py.File, source: Source):
         ("NXsource",),
     )
 
-    nxsource.create_dataset("name", data=np.string_(source.name))
+    nxsource.create_dataset("name", data=np.bytes_(source.name))
     create_attributes(nxsource["name"], ("short_name",), (source.short_name,))
-    nxsource.create_dataset("type", data=np.string_(source.facility_type))
+    nxsource.create_dataset("type", data=np.bytes_(source.facility_type))
     if source.probe:
-        nxsource.create_dataset("probe", data=np.string_(source.probe))
+        nxsource.create_dataset("probe", data=np.bytes_(source.probe))
 
 
 # NXdetector writer
@@ -398,10 +398,10 @@ def write_NXdetector(
 
     # Detector description
     nxdetector.create_dataset(
-        "description", data=np.string_(detector.detector_params.description)
+        "description", data=np.bytes_(detector.detector_params.description)
     )
     nxdetector.create_dataset(
-        "type", data=np.string_(detector.detector_params.detector_type)
+        "type", data=np.bytes_(detector.detector_params.detector_type)
     )
 
     collection_mode = detector.get_detector_mode()
@@ -498,7 +498,7 @@ def write_NXdetector(
 
     # Sensor material, sensor thickness in m
     nxdetector.create_dataset(
-        "sensor_material", data=np.string_(detector.detector_params.sensor_material)
+        "sensor_material", data=np.bytes_(detector.detector_params.sensor_material)
     )
     sensor_thickness = units_of_length(detector.detector_params.sensor_thickness, True)
     nxdetector.create_dataset("sensor_thickness", data=sensor_thickness.magnitude)
@@ -739,7 +739,7 @@ def write_NXcollection(
         if not detector_params.hasMeta or collection_mode == "events":
             grp.create_dataset(
                 "software_version",
-                data=np.string_(detector_params.constants["software_version"]),
+                data=np.bytes_(detector_params.constants["software_version"]),
             )
         elif detector_params.hasMeta and meta:
             grp["software_version"] = h5py.ExternalLink(
@@ -748,7 +748,7 @@ def write_NXcollection(
         else:
             grp.create_dataset(
                 "software_version",
-                data=np.string_(detector_params.constants["software_version"]),
+                data=np.bytes_(detector_params.constants["software_version"]),
             )
     if "EIGER" in detector_params.description.upper() and meta:
         for field in ["ntrigger"]:  # "data_collection_date", "eiger_fw_version"]
@@ -757,10 +757,10 @@ def write_NXcollection(
     elif "TRISTAN" in detector_params.description.upper():
         tick = ureg.Quantity(detector_params.constants["detector_tick"])
         grp.create_dataset("detector_tick", data=tick.magnitude)
-        grp["detector_tick"].attrs["units"] = np.string_(format(tick.units, "~"))
+        grp["detector_tick"].attrs["units"] = np.bytes_(format(tick.units, "~"))
         freq = ureg.Quantity(detector_params.constants["detector_frequency"])
         grp.create_dataset("detector_frequency", data=freq.magnitude)
-        grp["detector_frequency"].attrs["units"] = np.string_(format(freq.units, "~"))
+        grp["detector_frequency"].attrs["units"] = np.bytes_(format(freq.units, "~"))
         grp.create_dataset(
             "timeslice_rollover_bits",
             data=detector_params.constants["timeslice_rollover"],
@@ -798,7 +798,7 @@ def write_NXdatetime(
     if type(timestamp) is datetime:
         timestamp = timestamp.strftime("%Y-%m-%dT%H:%M:%S")
     timestamp = get_iso_timestamp(timestamp)
-    nxentry.create_dataset(dset_name, data=np.string_(timestamp))
+    nxentry.create_dataset(dset_name, data=np.bytes_(timestamp))
 
 
 # NXnote writer
@@ -825,7 +825,7 @@ def write_NXnote(nxsfile: h5py.File, loc: str, info: Dict):
     for k, v in info.items():
         if v:  # Just in case one value is not recorded and set as None
             if isinstance(v, str):
-                v = np.string_(v)
+                v = np.bytes_(v)
             nxnote.create_dataset(k, data=v)
             NXclass_logger.debug(f"{k} dataset written in {loc}.")
 
@@ -872,7 +872,7 @@ def write_NXcoordinate_system_set(
     )
 
     # Needs at least: 3 base vectors, depends_on ("." probably?), origin
-    transf.create_dataset("depends_on", data=np.string_("."))  # To be checked
+    transf.create_dataset("depends_on", data=np.bytes_("."))  # To be checked
     transf.create_dataset("origin", data=origin)
 
     # Base vectors

--- a/src/nexgen/nxs_write/write_utils.py
+++ b/src/nexgen/nxs_write/write_utils.py
@@ -29,6 +29,9 @@ def create_attributes(nxs_obj: h5py.Group | h5py.Dataset, names: Tuple, values: 
     """
     Create or overwrite attributes with additional metadata information.
 
+    If any of the values are strings, these will first be converted into fixed-width \
+    bytesrings.
+
     Args:
         nxs_obj (h5py.Group | h5py.Dataset): NeXus object to which the \
             attributes should be attached.
@@ -37,12 +40,12 @@ def create_attributes(nxs_obj: h5py.Group | h5py.Dataset, names: Tuple, values: 
     """
     for n, v in zip(names, values):
         if isinstance(v, str):
-            # If a string, convert to numpy.string_
-            v = np.string_(v)
+            # If a string, convert to a numpy bytestring
+            v = np.bytes_(v)
         h5py.AttributeManager.create(nxs_obj, name=n, data=v)
 
 
-def set_dependency(dep_info: str, path: str = None):
+def set_dependency(dep_info: str, path: str = None) -> np.bytes_:
     """
     Define value for "depends_on" attribute.
     If the attribute points to the head of the dependency chain, simply pass \
@@ -54,16 +57,17 @@ def set_dependency(dep_info: str, path: str = None):
         path (str): Where the transformation is. Set to None, if passed it \
             points to location in the NeXus tree.
     Returns:
-        The value to be passed to the attribute "depends_on"
+        The value to be passed to the attribute "depends_on" as a fixed-width \
+            bytestring.
     """
     if dep_info == ".":
-        return np.string_(".")
+        return np.bytes_(".")
     if path:
         if path.endswith("/") is False:
             path += "/"
-        return np.string_(path + dep_info)
+        return np.bytes_(path + dep_info)
     else:
-        return np.string_(dep_info)
+        return np.bytes_(dep_info)
 
 
 def calculate_origin(

--- a/src/nexgen/tools/data_writer.py
+++ b/src/nexgen/tools/data_writer.py
@@ -60,14 +60,14 @@ def build_an_eiger(
             :,
             i * eiger_mod_size[1]
             + (i - 1) * eiger_gap_size[1] : i * (eiger_mod_size[1] + eiger_gap_size[1]),
-        ] = -1
+        ] = 65535
     # Vertical modules
     for j in range(1, n_modules[1] + 1):
         IM[
             j * eiger_mod_size[0]
             + (j - 1) * eiger_gap_size[0] : j * (eiger_mod_size[0] + eiger_gap_size[0]),
             :,
-        ] = -1
+        ] = 65535
 
     # Intra module gap
     mid = []
@@ -76,7 +76,7 @@ def build_an_eiger(
             int(eiger_mod_size[1] / 2) + n * (eiger_mod_size[1] + eiger_gap_size[1])
         )
     for m in mid:
-        IM[:, (m - 1) : (m + 1)] = -1
+        IM[:, (m - 1) : (m + 1)] = 65535
 
     return IM
 
@@ -109,7 +109,7 @@ def build_a_tristan(
             + (i - 1)
             * tristan_gap_size[1] : i
             * (tristan_mod_size[1] + tristan_gap_size[1]),
-        ] = -1
+        ] = 65535
     # Vertical modules
     for j in range(1, n_modules[1] + 1):
         IM[
@@ -118,7 +118,7 @@ def build_a_tristan(
             * tristan_gap_size[0] : j
             * (tristan_mod_size[0] + tristan_gap_size[0]),
             :,
-        ] = -1
+        ] = 65535
 
     return IM
 

--- a/src/nexgen/tools/mrc_tools.py
+++ b/src/nexgen/tools/mrc_tools.py
@@ -172,9 +172,9 @@ def collect_data(files):
         )
 
         group = hdf5_file.create_group("entry")
-        group.attrs["NX_class"] = np.string_("NXentry")
+        group.attrs["NX_class"] = np.bytes_("NXentry")
         data_group = group.create_group("data")
-        data_group.attrs["NX_class"] = np.string_("NXdata")
+        data_group.attrs["NX_class"] = np.bytes_("NXdata")
 
         compressed_data = hdf5_file.create_dataset(
             "/entry/data/data", shape=dataset_shape, dtype=np.int32, **hdf5plugin.LZ4()

--- a/tests/nxs_write/conftest.py
+++ b/tests/nxs_write/conftest.py
@@ -98,7 +98,7 @@ def dummy_eiger_meta_file():
     test_meta_file["_dectris/detector_distance"] = np.array([0.19])
     test_meta_file["_dectris/bit_depth_readout"] = np.array([32])
     test_meta_file["flatfield"] = np.array([[0, 0, 0]])
-    test_meta_file["_dectris/software_version"] = np.string_("0.0.0")
+    test_meta_file["_dectris/software_version"] = np.bytes_("0.0.0")
     test_meta_file["mask"] = np.array([[0, 1, 1], [1, 0, 0]])
     test_meta_file["_dectris/pixel_mask_applied"] = False
     yield test_meta_file


### PR DESCRIPTION
In numpy 2.0 the `numpy.string_` alias for `numpy.bytes_` has been deprecated. This alias was used to write fixed-width bytestrings to h5 files in multiple places in the codebase. Replace with `numpy.bytes_` to avoid compatibility issues and to tidy up.

- [x] Use np.bytes_ everywhere instead of its deprecated alias
- [x] Unpin numpy