### PR TITLE
Re-enable external links for eiger meta file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Fixed
 - Numpy2.0 compatibility - stop using deprecated np.string_ alias for fixed-width bytestrings.
-
+- External links to eiger meta file in NXdetector and detectorSpecific groups re-enabled.
 
 
 ## 0.9.3

--- a/src/nexgen/nxs_utils/detector.py
+++ b/src/nexgen/nxs_utils/detector.py
@@ -29,11 +29,10 @@ EIGER_CONST = {
     "photon_energy": "_dectris/photon_energy",
     "software_version": "_dectris/software_version",
     "ntrigger": "/_dectris/ntrigger",
-    # "serial_number": "/_dectris/detector_number",
-    # "eiger_fw_version": "/_dectris/eiger_fw_version",
-    # "data_collection_date": "/_dectris/data_collection_date",
+    "serial_number": "/_dectris/detector_number",
+    "eiger_fw_version": "/_dectris/eiger_fw_version",
+    "data_collection_date": "/_dectris/data_collection_date",
 }
-# TODO see https://github.com/DiamondLightSource/nexgen/issues/236
 
 TRISTAN_CONST = {
     "flatfield": "Tristan10M_flat_field_coeff_with_Mo_17.479keV.h5",

--- a/src/nexgen/nxs_write/nxclass_writers.py
+++ b/src/nexgen/nxs_write/nxclass_writers.py
@@ -425,8 +425,6 @@ def write_NXdetector(
                 ]:
                     # NOTE: Software version, eiger_fw_version ntrigger & date should
                     # go in detectorSpecific (NXcollection)
-                    # TODO re-enable eiger_fw_version, date & serial_number
-                    # see https://github.com/DiamondLightSource/nexgen/issues/236
                     continue
                 nxdetector[k] = h5py.ExternalLink(meta_link, v)
         else:
@@ -751,8 +749,7 @@ def write_NXcollection(
                 data=np.bytes_(detector_params.constants["software_version"]),
             )
     if "EIGER" in detector_params.description.upper() and meta:
-        for field in ["ntrigger"]:  # "data_collection_date", "eiger_fw_version"]
-            # TODO See https://github.com/DiamondLightSource/nexgen/issues/236
+        for field in ["ntrigger", "data_collection_date", "eiger_fw_version"]:
             grp[field] = h5py.ExternalLink(meta.name, detector_params.constants[field])
     elif "TRISTAN" in detector_params.description.upper():
         tick = ureg.Quantity(detector_params.constants["detector_tick"])


### PR DESCRIPTION
Closes #236 

The string format issue in the meta file has been fixed in [eiger-detector version1.15.1](https://github.com/dls-controls/eiger-detector/releases/tag/1.15.1)