### PR TITLE
Extend MRC to Nexus converter to work with TVIPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
 # CHANGELOG
 
 
-## 0.9.#
-
+## 0.10.0
 
 ### Added
 - Small utility for creating directories when needed.
+- New wrapper function for serial nexus file for I19-2.
+- Serial functionality for i19 CLI.
+
+### Changed
+- Tidier parameter model for I19-2.
+
+### Fixed
+- Small bug in iso_timestamps where some formats were not properly handled.
 
 
 ## 0.9.10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "scanspec",
     "dataclasses-json",
     "pydantic",
+    "mrcfile>=1.5.3",
 ]
 license.file = "LICENSE"
 readme = "README.rst"

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -1,7 +1,7 @@
 Sphinx==7.3.7
 sphinx-rtd-theme==2.0.0
 autodoc_pydantic==2.2.0
-numpy==2.2.2
+numpy==2.2.6
 pint==0.24.4
 h5py==3.13.0
 hdf5plugin==5.0.0

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -3,7 +3,7 @@ sphinx-rtd-theme==2.0.0
 autodoc_pydantic==2.2.0
 numpy==2.2.2
 pint==0.24.4
-h5py==3.11.0
+h5py==3.13.0
 hdf5plugin==5.0.0
 freephil==0.2.1
 importlib_resources==6.5.2

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -8,4 +8,4 @@ hdf5plugin==5.0.0
 freephil==0.2.1
 importlib_resources==6.5.2
 scanspec==0.7.6
-pydantic==2.10.3
+pydantic==2.11.4

--- a/src/nexgen/beamlines/SSX_expt.py
+++ b/src/nexgen/beamlines/SSX_expt.py
@@ -68,7 +68,7 @@ def run_extruder(
         goniometer_axes[osc_idx], rotation=True, tot_num_imgs=num_imgs
     )
 
-    pump_info = pump_probe.dict()
+    pump_info = pump_probe.model_dump()
     logger.debug("Removing pump_repeat from pump probe necessary information.")
     pump_info.pop("pump_repeat")
 
@@ -187,7 +187,7 @@ def run_fixed_target(
         SCAN = {k: [val for val in v for _ in range(N)] for k, v in SCAN.items()}
     logger.info(f"Each position has been collected {N} times.")
     logger.info(f"Pump repeat setting: {chip_info['PUMP_REPEAT'][1]}.")
-    pump_info = pump_probe.dict()
+    pump_info = pump_probe.model_dump()
     pump_info["n_exposures"] = N
 
     return SCAN, pump_info
@@ -219,7 +219,7 @@ def run_3D_grid_scan(
 
     N = int(chip_info["N_EXPOSURES"][1])
 
-    pump_info = pump_probe.dict()
+    pump_info = pump_probe.model_dump()
     pump_info["repeat"] = int(chip_info["PUMP_REPEAT"][1])
     pump_info["n_exposures"] = N
     return None, None, pump_info

--- a/src/nexgen/beamlines/beamline_utils.py
+++ b/src/nexgen/beamlines/beamline_utils.py
@@ -5,10 +5,10 @@ Define and store basic beamline utilities.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 from typing import List, Optional, Sequence, Tuple
 
 from pydantic import BaseModel
+from pydantic.dataclasses import dataclass
 
 from nexgen.nxs_utils import Attenuator, Axis, Beam, Detector, Goniometer, Source
 from nexgen.utils import Point3D

--- a/src/nexgen/command_line/ED_mrc_to_nexus.py
+++ b/src/nexgen/command_line/ED_mrc_to_nexus.py
@@ -5,175 +5,424 @@ A script to convert a series of individual MRC images into a Nexus format.
 import logging
 import os
 from argparse import ArgumentParser
+from dataclasses import asdict, dataclass
+from logging import Logger
 from pathlib import Path
+from typing import List, Tuple
 
 import numpy as np
 
-from nexgen.beamlines.ED_params import ED_coord_system, EDCeta, EDSource
-from nexgen.nxs_utils import Attenuator, Beam, CetaDetector, Detector, Goniometer
+from nexgen.beamlines.ED_params import (
+    ED_coord_system,
+    EDCeta,
+    EDSource,
+)
+from nexgen.nxs_utils import (
+    Attenuator,
+    Beam,
+    CetaDetector,
+    Detector,
+    Goniometer,
+)
 from nexgen.nxs_utils.scan_utils import calculate_scan_points
 from nexgen.nxs_write.ed_nxmx_writer import EDNXmxFileWriter
-from nexgen.tools.mrc_tools import collect_data, get_metadata
+from nexgen.tools.mrc_tools import get_metadata, to_hdf5_data_file
 
 logger = logging.getLogger("nexgen.ED_mrc_to_nexus")
+logger.setLevel(logging.DEBUG)
+console_handler = logging.StreamHandler()  # Logs to stdout
+console_handler.setLevel(logging.DEBUG)
+formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+console_handler.setFormatter(formatter)
+logger.addHandler(console_handler)
 
 
-def main():
+@dataclass
+class Metadata:
+    mrc_files: List[str | Path]
+    detector_name: str = "unknown"
+    facility_name: str = "unknown"
+    facility_id: str = "unknown"
+    facility_short_name: str = "unknown"
+    facility_type: str = "Electron Source"
+    detector_distance: float = None
+    wavelength: float = None
+    angle_start: float = None
+    angle_increment: float = None
+    exposure_time: float = None
+    beam_center: Tuple[float, float] | List[float] = None
+    rotation_axis: Tuple[float, float, float] = (0, -1, 0)
+    fast_axis: Tuple[float, float, float] = (-1, 0, 0)
+    slow_axis: Tuple[float, float, float] = (0, -1, 0)
+    pixel_size: float = None
+    sensor_material: str = "Si"
+    sensor_thickness: float = 0.0
+    detector_type: str = "CMOS"
+    overload: float = None
+    underload: float = None
+    data_type: str = None
+    original_data_type: str = None
+    pixel_number_x: int = None
+    pixel_number_y: int = None
+    num_images: int = None
+    source: str = "electron"
 
-    parser = ArgumentParser(add_help=False)
-    parser.add_argument(
-        "--det_distance",
-        type=float,
-        default=None,
-        help="The sample-detector distance.",
-    )
-    parser.add_argument(
-        "-wl",
-        "--wavelength",
-        type=float,
-        default=None,
-        help="Incident beam wavelength, in A.",
-    )
-    parser.add_argument(
-        "--axis-start",
-        type=float,
-        default=None,
-        help="Rotation axis start position.",
-    )
-    parser.add_argument(
-        "--axis-inc",
-        type=float,
-        default=None,
-        help="Rotation axis increment.",
-    )
-    parser.add_argument(
-        "-e",
-        "--exp-time",
-        type=float,
-        help="Exposure time, in s.",
-    )
-    parser.add_argument(
-        "-bc",
-        "--beam-center",
-        type=float,
-        nargs=2,
-        help="Beam center (x,y) positions.",
-    )
-    parser.add_argument("input_files", nargs="+", help="List of input files")
 
-    args = parser.parse_args()
+def check_metadata(
+    metadata_template: Metadata,
+    logger: Logger,
+) -> None:
+    """Check if some metadata variables are not set"""
 
-    logger.info("Starting MRC to Nexus conversion")
-
-    for file in args.input_files:
-        if not file.endswith(".mrc"):
-            raise ValueError("Not an MRC file: %s" % file)
-
-    mrc_files = args.input_files
-    full_mrc_path = os.path.abspath(mrc_files[0])
-    logger.info("Collecting MRC data into a h5 file")
-    tot_imgs, out_file, angles = collect_data(mrc_files)
-
-    mdict = get_metadata(mrc_files[0])
-
-    attenuator = Attenuator(transmission=None)
-
-    if args.det_distance is not None:
-        det_distance = args.det_distance
-    elif "cameraLength" in mdict:
-        det_distance = mdict["cameraLength"]
-        msg = "Reading detector distance from "
-        msg += "the MRC files: %.1f" % det_distance
-        logger.info(msg)
-    else:
-        msg = "No detector distance in the MRC metadata. "
-        msg += "You can set it with -det_distance option."
-        raise ValueError(msg)
-
-    if args.wavelength is not None:
-        beam = Beam(args.wavelength)
-    elif "wavelength" in mdict:
-        beam = Beam(mdict["wavelength"])
-        msg = "Reading wavelength from the MRC files: %f" % mdict["wavelength"]
-        logger.info(msg)
-    else:
-        msg = "No wavelength in the MRC metadata. "
-        msg += "You can set it with --wavelength option."
-        raise ValueError(msg)
-
-    if args.axis_start is not None:
-        start_angle = args.axis_start
-    elif angles[0] is not None:
-        start_angle = angles[0]
-        msg = "Reading starting angle from the MRC files: %.2f" % start_angle
-        logger.info(msg)
-    else:
-        msg = "No starting angle in the MRC metadata. "
-        msg += "You can set it with --axis_start option."
-        raise ValueError(msg)
-
-    if args.axis_inc is not None:
-        increment = args.axis_inc
-    elif "tiltPerImage" in mdict:
-        increment = mdict["tiltPerImage"]
-        msg = "Reading angle increment from the MRC files: %f" % increment
-        logger.info(msg)
-    else:
-        msg = "No angle increment in the MRC metadata. "
-        msg += "You can set it with --axis_inc option."
-        raise ValueError(msg)
-
-    if args.exp_time is not None:
-        exposure_time = args.exp_time
-    elif "integrationTime" in mdict:
-        exposure_time = mdict["integrationTime"]
-        msg = "Reading exposure time from the MRC files: %f" % exposure_time
-        logger.info(msg)
-    else:
-        msg = "No exposure time in the MRC metadata. "
-        msg += "You can set it with --exp_time option."
-        raise ValueError(msg)
-
-    if args.beam_center is not None:
-        if len(args.beam_center) == 2:
-            x, y = args.beam_center
-            beam_center = (x, y)
-        else:
-            msg = "Beam center requires two arguments"
+    for key, value in asdict(metadata_template).items():
+        if value is None:
+            msg = f"Metadata {key} is not set."
             raise ValueError(msg)
-    elif ("beamCentreXpx" in mdict) and ("beamCentreYpx" in mdict):
-        beam_center = (mdict["beamCentreXpx"], mdict["beamCentreYpx"])
-        msg = "Reading beam center from the MRC files: (%.1f, %.1f)" % beam_center
-        logger.info(msg)
+
+    logger.info("Listing parameters to be written in the Nexus file: ")
+    log_dict(logger, metadata_template)
+
+
+def overwrite_from_tvips(
+    metadata_template: Metadata, logger: Logger, mrc_metadata: dict
+) -> None:
+    """Set default parameters describing TVIPS detector"""
+
+    m = metadata_template
+
+    nx = mrc_metadata["nx"]
+    ny = mrc_metadata["ny"]
+
+    if (nx == 4096) and (ny == 4096):
+        binning = 1
+    elif (nx == 2048) and (ny == 2048):
+        binning = 2
+    elif (nx == 1024) and (ny == 1024):
+        binning = 4
+    elif (nx == 512) and (ny == 512):
+        binning = 8
     else:
-        msg = "No beam center in the MRC metadata. "
-        msg += "You can set it with --beam_center option."
+        msg = f"Non standard detector size ({nx}, {ny})."
+        msg += "Expecting (4096/b, 4096/b) with binning b = 1, 2, 4, 8"
         raise ValueError(msg)
 
-    gonio_axes = EDCeta.gonio
-    gonio_axes[0].start_pos = start_angle
-    gonio_axes[0].increment = increment
-    gonio_axes[0].num_steps = tot_imgs
+    m.detector_name = "TVIPS Detector"
+    m.pixel_size = 0.015500 * binning
+    m.overload = 8000 * binning**2
+    m.underload = 0
+    m.beamline = "TVIPS"
+    m.rotation_axis = (1, 0, 0)
+    logger.info("Setting default TVIPS parameters.")
 
-    scan = calculate_scan_points(gonio_axes[0], rotation=True, tot_num_imgs=tot_imgs)
-    goniometer = Goniometer(gonio_axes, scan)
 
-    nx = mdict["nx"]
-    ny = mdict["ny"]
+def overwrite_from_cetad(
+    metadata_template: Metadata, logger: Logger, mrc_metadata: dict
+) -> dict:
+    """Set default parameters describing CetaD detector"""
+
+    m = metadata_template
+    msg = "Nexus file does not save detector gain. Gain for Ceta-D is 26."
+    logger.warning(msg)
+
+    m.detector_name = "Thermo Fisher Ceta-D"
+    nx = mrc_metadata["nx"]
+    ny = mrc_metadata["ny"]
+
+    m.pixel_num_x = nx
+    m.pixel_num_y = ny
 
     if (nx == 2048) and (ny == 2048):
         binning = 2
     else:
         binning = 1
 
-    det_params = CetaDetector("Thermo Fisher Ceta-D", [nx, ny])
+    m.pixel_size = 0.014 * binning
+    m.overload = 8000 * binning**2
+    m.underload = -1000
+    m.facility = "Diamond Light Source"
+    m.facility_short_name = ""
+    m.facility_type = "Electron Source"
+    m.facility_id = "DIAMOND"
+    m.beamline = "Ceta-D-eBIC"
+    m.data_type = "int32"
 
-    pixel_size = 0.014 * binning
-    ps_str = "%5.3fmm" % pixel_size
+    logger.info("Setting default Ceta-D parameters.")
+
+
+def overwrite_from_mrc(metadata_template, logger, mrc_metadata):
+    """Overwrites the metadata template with metadata from the MRC file"""
+
+    if len(mrc_metadata["data_shape"]) == 3:
+        metadata_template.num_images = mrc_metadata["data_shape"][0]
+    else:
+        metadata_template.num_images = len(metadata_template.mrc_files)
+
+    if "cameraLength" in mrc_metadata:
+        metadata_template.detector_distance = mrc_metadata["cameraLength"]
+        msg = "Setting detector distance from the MRC files: "
+        msg += "%.1f" % mrc_metadata["cameraLength"]
+        logger.info(msg)
+
+    if "wavelength" in mrc_metadata:
+        metadata_template.wavelength = mrc_metadata["wavelength"]
+        msg = "Setting wavelength from the MRC files: "
+        msg += f"{mrc_metadata['wavelength']}"
+        logger.info(msg)
+
+    if "alphaTilt" in mrc_metadata:
+        metadata_template.angle_start = mrc_metadata["alphaTilt"]
+        msg = "Setting starting angle (alphaTilt) from the MRC files: "
+        msg += f"{mrc_metadata['alphaTilt']}"
+        logger.info(msg)
+
+    if "tiltPerImage" in mrc_metadata:
+        metadata_template.angle_increment = mrc_metadata["tiltPerImage"]
+        msg = "Setting rotation angle increment from the MRC files: "
+        msg += "%f" % mrc_metadata["tiltPerImage"]
+        logger.info(msg)
+
+    if "integrationTime" in mrc_metadata:
+        metadata_template.exposure_time = mrc_metadata["integrationTime"]
+        msg = "Setting exposure time from the MRC files: "
+        msg += "%f" % mrc_metadata["integrationTime"]
+        logger.info(msg)
+
+    if ("beamCentreXpx" in mrc_metadata) and ("beamCentreYpx" in mrc_metadata):
+        bc = (mrc_metadata["beamCentreXpx"], mrc_metadata["beamCentreYpx"])
+        metadata_template.beam_center = bc
+        msg = "Setting beam center from the MRC files: (%.1f, %.1f)" % bc
+        logger.info(msg)
+
+    m = metadata_template
+    m.data_type = "%s" % mrc_metadata["original_data_type"]
+    m.original_data_type = "%s" % mrc_metadata["original_data_type"]
+    msg = "Default data type in the MRC files: "
+    msg += "%s" % mrc_metadata["original_data_type"]
+    logger.info(msg)
+
+    m.pixel_number_x = mrc_metadata["nx"]
+    m.pixel_number_y = mrc_metadata["ny"]
+
+
+def overwrite_from_command_line(
+    template: Metadata, logger: Logger, cmd_args: dict, mrc_metadata: dict
+) -> None:
+    """Overwrite the metadata with the arguments from the command line"""
+
+    if cmd_args.detector_name is not None:
+        template.detector_name = cmd_args.detector_name
+        msg = "Detector name overwritten from the command line: "
+        msg += cmd_args.detector_name
+        logger.info(msg)
+
+    if cmd_args.facility_name is not None:
+        template.facility_name = cmd_args.facility_name
+        msg = "Facility overwritten from the command line: "
+        msg += cmd_args.facility_name
+        logger.info(msg)
+
+    if cmd_args.facility_id is not None:
+        template.facility_id = cmd_args.facility_id
+        msg = "Facility ID overwritten from the command line: "
+        msg += cmd_args.facility_id
+        logger.info(msg)
+
+    if cmd_args.facility_short_name is not None:
+        template.facility_short_name = cmd_args.facility_short_name
+        msg = "Facility short name overwritten from the command line: "
+        msg += cmd_args.facility_short_name
+        logger.info(msg)
+
+    if cmd_args.detector_distance is not None:
+        template.detector_distance = cmd_args.detector_distance
+        msg = "Detector distance overwritten from the command line: "
+        msg += "%f" % cmd_args.detector_distance
+        logger.info(msg)
+
+    if cmd_args.wavelength is not None:
+        template.wavelength = cmd_args.wavelength
+        msg = "Wavelength overwritten from the command line: "
+        msg += "%f" % cmd_args.wavelength
+        logger.info(msg)
+
+    if cmd_args.angle_start is not None:
+        template.angle_start = cmd_args.angle_start
+        msg = "Starting angle overwritten from the command line: "
+        msg += "%f" % cmd_args.angle_start
+        logger.info(msg)
+
+    if cmd_args.angle_increment is not None:
+        template.angle_increment = cmd_args.angle_increment
+        msg = "Angle increment overwritten from the command line: "
+        msg += "%f" % cmd_args.angle_increment
+        logger.info(msg)
+
+    if cmd_args.exposure_time is not None:
+        template.exposure_time = cmd_args.exposure_time
+        msg = "Exposure time overwritten from the command line: "
+        msg += "%f" % cmd_args.exposure_time
+        logger.info(msg)
+
+    if cmd_args.beam_center is not None:
+        template.beam_center = cmd_args.beam_center
+        x, y = cmd_args.beam_center
+        msg = "Beam center overwritten from the command line: "
+        msg += f"{x:.2f}, {y:.2f}"
+        logger.info(msg)
+
+    if cmd_args.rotation_axis is not None:
+        template.rotation_axis = cmd_args.rotation_axis
+        x, y, z = cmd_args.rotation_axis
+        msg = "Rotation axis overwritten from the command line: "
+        msg += "(%.1f, %.1f, %.1f)" % (x, y, z)
+        logger.info(msg)
+
+    if cmd_args.slow_axis is not None:
+        template.slow_axis = cmd_args.slow_axis
+        x, y, z = cmd_args.slow_axis
+        msg = "Slow axis overwritten from the command line: "
+        msg += "(%.1f, %.1f, %.1f)" % (x, y, z)
+        logger.info(msg)
+
+    if cmd_args.fast_axis is not None:
+        template.fast_axis = cmd_args.fast_axis
+        x, y, z = cmd_args.fast_axis
+        msg = "Fast axis overwritten from the command line: "
+        msg += "(%.1f, %.1f, %.1f)" % (x, y, z)
+        logger.info(msg)
+
+    if cmd_args.pixel_size is not None:
+        template.pixel_size = cmd_args.pixel_size
+        msg = "Pixel size overwritten from the command line: "
+        msg += "%.10f" % cmd_args.pixel_size
+        logger.info(msg)
+
+    if cmd_args.sensor_material is not None:
+        template.sensor_material = cmd_args.sensor_material
+        msg = "Sensor material overwritten from the command line: "
+        msg += "%s" % cmd_args.sensor_material
+        logger.info(msg)
+
+    if cmd_args.sensor_thickness is not None:
+        template.sensor_thickness = cmd_args.sensor_thickness
+        msg = "Sensor thickness overwritten from the command line: "
+        msg += "%f" % cmd_args.sensor_thickness
+        logger.info(msg)
+    if abs(template.sensor_thickness - 0.0) < 1.0e-30:
+        template.sensor_thickness = 1.0e-30
+        msg = "Sensor thickness can not be zero. Setting it to 1.e-15."
+        logger.info(msg)
+
+    if cmd_args.detector_type is not None:
+        template.detector_type = cmd_args.detector_type
+        msg = "Detector type overwritten from the command line: "
+        msg += "%s" % cmd_args.detector_type
+        logger.info(msg)
+
+    if cmd_args.data_type is not None:
+        template.data_type = cmd_args.data_type
+        msg = "Data type overwritten from the command line: "
+        msg += "%s" % cmd_args.data_type
+        logger.info(msg)
+
+    if cmd_args.source is not None:
+        template.source = cmd_args.source
+        msg = "Source overwritten from the command line: "
+        msg += "%s" % cmd_args.source
+        logger.info(msg)
+
+    if cmd_args.overload is not None:
+        template.overload = cmd_args.overload
+        msg = "Detector overload overwritten from the command line: "
+        msg += "%d" % cmd_args.overload
+        logger.info(msg)
+
+    if cmd_args.underload is not None:
+        template.underload = cmd_args.underload
+        msg = "Detector underload overwritten from the command line: "
+        msg += "%d" % cmd_args.underload
+        logger.info(msg)
+
+
+def log_dict(logger: Logger, dictionary: dict, skip: List = None) -> None:
+
+    if skip is None:
+        skip = [1]
+
+    msg = ""
+    for index, (name, value) in enumerate(asdict(dictionary).items()):
+        if index in skip:
+            buffer = ""
+        else:
+            buffer = 33 * " "
+
+        if index != len(asdict(dictionary)) - 1:
+            end_string = "\n"
+        else:
+            end_string = ""
+
+        if value is not None and name != "mrc_files":
+            msg += buffer + f"{name} = {value}" + end_string
+    logger.info(msg)
+
+
+def main():
+
+    args = parse_input_arguments()
+    metadata_template = Metadata(args.input_files)
+    logger.info("Starting MRC to Nexus conversion.")
+
+    for file in args.input_files:
+        if not file.endswith(".mrc"):
+            raise ValueError("Not an MRC file: %s" % file)
+
+    mrc_files = args.input_files
+    mrc_metadata = get_metadata(mrc_files[0])
+    logger.info("Collecting MRC data into a HDF5 h5 file.")
+
+    if args.detector == "cetad":
+        logger.info("Detector set to cetad.")
+        overwrite_from_cetad(metadata_template, logger, mrc_metadata)
+    elif args.detector == "tvips":
+        logger.info("Detector set to tvips.")
+        overwrite_from_tvips(metadata_template, logger, mrc_metadata)
+
+    overwrite_from_mrc(metadata_template, logger, mrc_metadata)
+    overwrite_from_command_line(metadata_template, logger, args, mrc_metadata)
+    check_metadata(metadata_template, logger)
+
+    m = metadata_template
+
+    gonio_axes = EDCeta.gonio
+    gonio_axes[0].start_pos = m.angle_start
+    gonio_axes[0].increment = m.angle_increment
+    gonio_axes[0].num_steps = m.num_images
+    EDCeta.gonio[0].vector = m.rotation_axis
+    EDCeta.fast_axis = m.fast_axis
+    EDCeta.slow_axis = m.slow_axis
+
+    scan = calculate_scan_points(
+        gonio_axes[0], rotation=True, tot_num_imgs=m.num_images
+    )
+
+    goniometer = Goniometer(gonio_axes, scan)
+
+    hdf5_file = to_hdf5_data_file(mrc_files, logger, dtype=metadata_template.data_type)
+
+    det_params = CetaDetector(m.detector_name, [m.pixel_number_x, m.pixel_number_y])
+
+    ps_str = "%5.7fmm" % m.pixel_size
     det_params.pixel_size = [ps_str, ps_str]
-    det_params.overload = 8000 * binning**2
+    det_params.sensor_material = m.sensor_material
+    det_params.sensor_thickness = m.sensor_thickness
+    det_params.overload = m.overload
+    det_params.underload = m.underload
+    det_params.detector_type = m.detector_type
 
     extra_params = {}
+    nx = m.pixel_number_x
+    ny = m.pixel_number_y
+
     mask = np.zeros((nx, ny), dtype=np.int32)
     flatfield = np.ones((nx, ny), dtype=np.float32)
     extra_params["pixel_mask"] = mask
@@ -183,40 +432,225 @@ def main():
     det_params.constants.update(extra_params)
 
     det_axes = EDCeta.det_axes
+    det_axes[0].start_pos = m.detector_distance
 
-    det_axes[0].start_pos = det_distance
+    EDSource.beamline = m.facility_name
+    EDSource.facility_id = m.facility_id
+    EDSource.facility_type = m.facility_type
+    EDSource.probe = m.source
+    EDSource.short_name = m.facility_short_name
+
+    beam = Beam(m.wavelength)
 
     detector = Detector(
         det_params,
         det_axes,
-        beam_center,
-        exposure_time,
+        m.beam_center,
+        m.exposure_time,
         [EDCeta.fast_axis, EDCeta.slow_axis],
     )
 
-    source = EDSource
-    source.beamline = "Ceta"
+    path = os.getcwd()
 
-    script_dir = os.path.dirname(full_mrc_path)
-    file_name = out_file.replace("h5", "nxs")
-    full_path = os.path.join(script_dir, file_name)
-    data_path = os.path.join(script_dir, out_file)
+    nexus_file = hdf5_file.replace("h5", "nxs")
+    nexus_path = os.path.join(path, nexus_file)
+
+    data_path = os.path.join(path, hdf5_file)
     data_path = Path(data_path)
 
-    msg = "Writing the Nexus file %s" % full_path
-    logger.info(msg)
+    logger.info("Writing Nexus file.")
+
+    attenuator = Attenuator(transmission=None)
+
     writer = EDNXmxFileWriter(
-        full_path,
+        nexus_path,
         goniometer,
         detector,
-        source,
+        EDSource,
         beam,
         attenuator,
-        tot_imgs,
+        m.num_images,
         ED_coord_system,
     )
 
-    datafiles = [data_path]
-    writer.write(datafiles, "/entry/data/data")
-    writer.write_vds(vds_dtype=np.int32, datafiles=datafiles)
+    writer.write([data_path], "/entry/data/data")
+    writer.write_vds(vds_dtype=m.data_type, datafiles=[data_path])
     logger.info("MRC images converted to Nexus.")
+
+
+def parse_input_arguments():
+
+    msg = "Convert electron diffraction data from an MRC format "
+    msg += "to a NeXus format"
+    parser = ArgumentParser(description=msg, add_help=True)
+
+    parser.add_argument(
+        "--detector",
+        type=str,
+        default="cetad",
+        choices=["cetad", "tvips", "unknown"],
+        help="Detector type.",
+    )
+
+    parser.add_argument(
+        "--detector-name",
+        type=str,
+        help="Detector name.",
+    )
+
+    parser.add_argument(
+        "--facility-name",
+        type=str,
+        default=None,
+        help="Name of the facility (e.g. Diamond Light Source).",
+    )
+
+    parser.add_argument(
+        "--facility-short-name",
+        type=str,
+        default=None,
+        help="Short name of the facility (e.g. DLS).",
+    )
+
+    parser.add_argument(
+        "--facility-type",
+        type=str,
+        default=None,
+        help="Facility type (e.g. Electron Source).",
+    )
+
+    msg = "Facility ID (e.g. DIAMOND). "
+    msg += "Naming tries to follow the recommended convention for NXmx: "
+    msg += "https://mmcif.wwpdb.org/dictionaries/"
+    msg += "mmcif_pdbx_v50.dic/Items/_diffrn_source.type.html"
+    parser.add_argument("--facility-id", type=str, default=None, help=msg)
+
+    parser.add_argument(
+        "--detector-distance",
+        type=float,
+        default=None,
+        help="The sample-detector distance (in mm).",
+    )
+
+    parser.add_argument(
+        "-wl",
+        "--wavelength",
+        type=float,
+        default=None,
+        help="Incident beam wavelength (in Angstroms).",
+    )
+
+    parser.add_argument(
+        "--angle-start",
+        type=float,
+        default=None,
+        help="Starting angle of a rotation scan (degrees).",
+    )
+
+    parser.add_argument(
+        "--angle-increment",
+        type=float,
+        default=None,
+        help="Angle increment of a rotation scan (degrees).",
+    )
+
+    parser.add_argument(
+        "-e",
+        "--exposure-time",
+        type=float,
+        help="Exposure time (in seconds).",
+    )
+
+    parser.add_argument(
+        "-bc",
+        "--beam-center",
+        type=float,
+        nargs=2,
+        help="Beam center (x, y) or (fast, slow), in pixels.",
+    )
+
+    parser.add_argument(
+        "--rotation-axis",
+        type=float,
+        nargs=3,
+        help="Rotation axis (x, y, z).",
+    )
+
+    parser.add_argument(
+        "--fast-axis",
+        type=float,
+        nargs=3,
+        help="Detector fast axis (x, y, z).",
+    )
+
+    parser.add_argument(
+        "--slow-axis",
+        type=float,
+        nargs=3,
+        help="Detector slow axis (x, y, z).",
+    )
+
+    parser.add_argument(
+        "--data-type",
+        type=str,
+        default=None,
+        help="Data type for the HDF5 output (int32, int64, float64, ...).",
+    )
+
+    parser.add_argument(
+        "--source",
+        type=str,
+        default=None,
+        help="Source type (e.g. electron, x-ray).",
+    )
+
+    parser.add_argument(
+        "--pixel-size",
+        type=float,
+        default=None,
+        help="Pixel size in mm.",
+    )
+
+    parser.add_argument(
+        "--sensor-material",
+        type=str,
+        default=None,
+        help="Sensor material (e.g. Si).",
+    )
+
+    parser.add_argument(
+        "--sensor-thickness",
+        type=float,
+        default=None,
+        help="Sensor thickness.",
+    )
+
+    parser.add_argument(
+        "--detector-type",
+        type=str,
+        default=None,
+        help="Detector type (e.g. CMOS).",
+    )
+
+    parser.add_argument(
+        "--overload",
+        type=float,
+        default=None,
+        help="Upper limit of the trusted range.",
+    )
+
+    parser.add_argument(
+        "--underload",
+        type=float,
+        default=None,
+        help="Lower limit of the trusted range.",
+    )
+
+    des = "List of input files. Can be a single MRC file containing all the "
+    des += "images, or a list of files containing single images, "
+    des += "usually obtained by global expansion (e.g. *mrc)"
+    parser.add_argument("input_files", nargs="+", help=des)
+
+    args = parser.parse_args()
+
+    return args

--- a/src/nexgen/command_line/I19_2_cli.py
+++ b/src/nexgen/command_line/I19_2_cli.py
@@ -5,10 +5,19 @@ Available detectors: Tristan 10M, Eiger 2X 4M.
 
 import argparse
 import logging
-from collections import namedtuple
 from datetime import datetime
+from pathlib import Path
+
+from nexgen.utils import get_nexus_filename
 
 from .. import log
+from ..beamlines.I19_2_gda_nxs import write_nxs
+from ..beamlines.I19_2_nxs import (
+    DetAxisPosition,
+    GonioAxisPosition,
+    nexus_writer,
+    serial_nexus_writer,
+)
 from . import version_parser
 
 logger = logging.getLogger("nexgen.I19-2_NeXus_cli")
@@ -26,8 +35,6 @@ def gda_writer(args):
     """
     logger.info("Create a NeXus file for I19-2 interfacing with GDA.")
 
-    from ..beamlines.I19_2_gda_nxs import write_nxs
-
     write_nxs(
         meta_file=args.meta_file,
         xml_file=args.xml_file,
@@ -43,19 +50,22 @@ def gda_writer(args):
         ),
         stop_time=(
             datetime.strptime(args.stop, "%Y-%m-%dT%H:%M:%SZ") if args.stop else None
-        ),  # datetime.now(),
+        ),
         geometry_json=args.geom if args.geom else None,
         detector_json=args.det if args.det else None,
     )
 
 
-def nexgen_writer(args):
-    """
-    Write a NXmx format NeXus file from the I19-2 beamline.
-    """
-    logger.info("Create a NeXus file for I19-2 data.")
-
-    from ..beamlines.I19_2_nxs import axes, det_axes, nexus_writer
+def parse_input_arguments(args):
+    """Perform a series of checks on the nexgen CLI parsed arguments."""
+    # Check that an actual meta file has been passed and not a data file
+    if "meta" not in args.meta_file:
+        logger.error(
+            f"Wrong input file passed: {args.meta_file}. Please pass the _meta.h5 file for this dataset."
+        )
+        raise OSError(
+            "The input file passed is not a _meta.h5 file. Please pass the correct file."
+        )
 
     if args.axes and not args.ax_start:
         raise OSError(
@@ -73,51 +83,67 @@ def nexgen_writer(args):
             )
             raise OSError("Missing axes values.")
 
+
+def nexgen_writer(args):
+    """
+    Write a NXmx format NeXus file from the I19-2 beamline.
+    """
+    expt_type = "standard" if args.serial is False else "serial"
+    logger.info(f"Create a NeXus file for a {expt_type} I19-2 data collection.")
+    parse_input_arguments(args)
+
+    axes_list = []
+    det_list = []
     if args.axes and args.ax_start:
         if args.detector_name == "eiger":
-            axes_list = []
             for ax, s, i in zip(args.axes, args.ax_start, args.ax_inc):
-                axes_list.append(axes(id=ax, start=s, inc=i))
+                axes_list.append(GonioAxisPosition(id=ax, start=s, inc=i))
         else:
-            axes = namedtuple("axes", ("id", "start", "end"))
-            axes_list = []
             for ax, s, e in zip(args.axes, args.ax_start, args.ax_end):
-                axes_list.append(axes(id=ax, start=s, end=e))
+                axes_list.append(GonioAxisPosition(id=ax, start=s, end=e))
 
     if args.det_axes and args.det_start:
-        det_list = []
         for ax, s in zip(args.det_axes, args.det_start):
-            det_list.append(det_axes(id=ax, start=s))
+            det_list.append(DetAxisPosition(id=ax, start=s))
 
-    # Check that an actual meta file has been passed and not a data file
-    if "meta" not in args.meta_file:
-        logger.error(
-            f"Wrong input file passed: {args.meta_file}. Please pass the _meta.h5 file for this dataset."
-        )
-        raise OSError(
-            "The input file passed is not a _meta.h5 file. Please pass the correct file."
-        )
+    params = {
+        "exposure_time": args.exp_time,
+        "beam_center": args.beam_center if args.beam_center else (0, 0),
+        "wavelength": args.wavelength if args.wavelength else None,
+        "transmission": args.transmission if args.transmission else None,
+        "metafile": args.meta_file,
+        "detector_name": args.detector_name,
+        "tot_num_images": args.num_imgs if args.num_imgs else None,
+        "scan_axis": args.scan_axis if args.scan_axis else "phi",
+        "axes_pos": axes_list if len(axes_list) > 0 else None,
+        "det_pos": det_list if len(det_list) > 0 else None,
+    }
 
-    nexus_writer(
-        meta_file=args.meta_file,
-        detector_name=args.detector_name,
-        exposure_time=args.exp_time,
-        transmission=args.transmission if args.transmission else None,
-        wavelength=args.wavelength if args.wavelength else None,
-        beam_center=args.beam_center if args.beam_center else (0, 0),
-        start_time=(
-            datetime.strptime(args.start, "%Y-%m-%dT%H:%M:%SZ") if args.start else None
-        ),
-        stop_time=(
-            datetime.strptime(args.stop, "%Y-%m-%dT%H:%M:%SZ") if args.stop else None
-        ),
-        n_imgs=args.num_imgs if args.num_imgs else None,
-        scan_axis=args.scan_axis if args.scan_axis else "phi",
-        gonio_pos=axes_list if args.axes else None,
-        det_pos=det_list if args.det_axes else None,
-        outdir=args.output if args.output else None,
-        use_meta=args.use_meta,
-    )
+    master_file = get_nexus_filename(args.meta_file)
+
+    if args.outdir:
+        _wdir = Path(args.outdir).expanduser().resolve()
+        master_file = _wdir / master_file.name
+
+    _start = datetime.strptime(args.start, "%Y-%m-%dT%H:%M:%SZ") if args.start else None
+    _stop = datetime.strptime(args.stop, "%Y-%m-%dT%H:%M:%SZ") if args.stop else None
+
+    if expt_type == "serial":
+        serial_nexus_writer(
+            params,
+            master_file,
+            (_start, _stop),
+            args.use_meta,
+            args.vds_offset,
+            args.n_frames,
+        )
+    else:
+        nexus_writer(
+            params,
+            master_file,
+            (_start, _stop),
+            args.use_meta,
+        )
 
 
 # Define a couple of useful parsers for axes positions
@@ -147,6 +173,14 @@ detAx_parser.add_argument(
     "--det-start", type=float, nargs="+", help="Detector axes start positions."
 )
 
+timestamps_parser = argparse.ArgumentParser(add_help=False)
+timestamps_parser.add_argument(
+    "--start", "--start-time", type=str, default=None, help="Collection start time."
+)
+timestamps_parser.add_argument(
+    "--stop", "--stop-time", type=str, default=None, help="Collection end time."
+)
+
 # Define subparsers
 subparsers = parser.add_subparsers(
     help="Choice depending on how the data collection is run: from GDA or independently of it. \
@@ -161,6 +195,7 @@ parser_gda = subparsers.add_parser(
     description=(
         "Trigger the NeXus file writer interface with GDA for I19-2 data collection."
     ),
+    parents=[timestamps_parser],
 )
 parser_gda.add_argument("meta_file", type=str, help="Path to _meta.h5 file.")
 parser_gda.add_argument("xml_file", type=str, help="Path to GDA generated xml file.")
@@ -177,12 +212,6 @@ parser_gda.add_argument(
 )
 parser_gda.add_argument(
     "beam_center_y", type=str, help="Beam center y position, in pixels."
-)
-parser_gda.add_argument(
-    "--start", "--start-time", type=str, default=None, help="Collection start time."
-)
-parser_gda.add_argument(
-    "--stop", "--stop-time", type=str, default=None, help="Collection end time."
 )
 parser_gda.add_argument(
     "--geom",
@@ -204,19 +233,22 @@ parser_nex = subparsers.add_parser(
     "2",
     aliases=["gen"],
     description=("Trigger the NeXus file writer for I19-2 data collection."),
-    parents=[gonioAx_parser, detAx_parser],
+    parents=[gonioAx_parser, detAx_parser, timestamps_parser],
 )
 parser_nex.add_argument("meta_file", type=str, help="Path to _meta.h5 file.")
 parser_nex.add_argument(
-    "detector_name", type=str, help="Detector currently in use on beamline."
+    "detector-name",
+    type=str,
+    choices=["eiger", "tristan"],
+    help="Detector currently in use on beamline.",
 )
-parser_nex.add_argument("exp_time", type=float, help="Exposure time, in s.")
+parser_nex.add_argument("exp-time", type=float, help="Exposure time, in s.")
 parser_nex.add_argument(
     "-n",
-    "--num_imgs",
+    "--num-imgs",
     type=int,
     default=None,
-    help="Number of frames collected. Necessary for eiger if not using meta file.",
+    help="Number of images collected. Necessary for eiger if not using meta file.",
 )
 parser_nex.add_argument(
     "-tr",
@@ -240,12 +272,6 @@ parser_nex.add_argument(
     help="Beam center (x,y) positions.",
 )
 parser_nex.add_argument(
-    "--start", "--start-time", type=str, default=None, help="Collection start time."
-)
-parser_nex.add_argument(
-    "--stop", "--stop-time", type=str, default=None, help="Collection end time."
-)
-parser_nex.add_argument(
     "-o",
     "--output",
     type=str,
@@ -255,6 +281,22 @@ parser_nex.add_argument(
     "--use-meta",
     action="store_true",
     help="If passed, for Eiger metadata will be read from meta.h5 file. No action for Tristan.",
+)
+parser_nex.add_argument(
+    "--serial", action="store_true", help="Option to pass for a serial dataset."
+)
+parser_nex.add_argument(
+    "--vds-offset",
+    type=int,
+    default=0,
+    help="Start index for the vds writer. Mostly used for serial collections to separate wells \
+        into different nexus files. If not passed defaults to 0",
+)
+parser_nex.add_argument(
+    "--frames",
+    type=int,
+    help="Number of frames in the nexus and vds file. Only passed if different from total number \
+        of images collected.",
 )
 parser_nex.set_defaults(func=nexgen_writer)
 

--- a/src/nexgen/nxs_copy/copy_utils.py
+++ b/src/nexgen/nxs_copy/copy_utils.py
@@ -307,7 +307,7 @@ def compute_ssx_axes(
             }
 
         # Update pump probe
-        pump_info = pp.dict()
+        pump_info = pp.model_dump()
         pump_info["n_exposures"] = N_EXP
         return OSC, TRANSL, pump_info, None
     else:
@@ -315,4 +315,4 @@ def compute_ssx_axes(
         # Do not set N_EXP, there should be no repeat here
         # Find out how many consecutive windows are binned together.
         windows_per_bin = (num_blocks * chip.tot_windows_per_block()) // nbins
-        return OSC, {}, pp.dict(), windows_per_bin
+        return OSC, {}, pp.model_dump(), windows_per_bin

--- a/src/nexgen/nxs_utils/__init__.py
+++ b/src/nexgen/nxs_utils/__init__.py
@@ -10,6 +10,7 @@ from .detector import (
     JungfrauDetector,
     SinglaDetector,
     TristanDetector,
+    TVIPSDetector,
 )
 from .goniometer import Goniometer
 from .sample import Sample
@@ -33,4 +34,5 @@ __all__ = [
     "TransformationType",
     "Facility",
     "CetaDetector",
+    "TVIPSDetector"
 ]

--- a/src/nexgen/nxs_utils/detector.py
+++ b/src/nexgen/nxs_utils/detector.py
@@ -69,6 +69,35 @@ CETA_CONST = {
     "software_version": "0.0.0",
 }
 
+TVIPS_CONST = {
+    "flatfield": None,
+    "flatfield_applied": False,
+    "pixel_mask": None,
+    "pixel_mask_applied": False,
+    "software_version": "0.0.0",
+}
+
+
+@dataclass
+class TVIPSDetector(DataClassJsonMixin):
+    """Define a TVIPS camera """
+
+    description: str
+    image_size: List[float] | Tuple[float]
+    pixel_size: str = "0.0155000mm"
+    sensor_material: str = "Si"
+    sensor_thickness: str = "0.0000000000001mm"
+    detector_type: str = "CMOS"
+    overload: int = 65534
+    underload: int = 0
+
+    @property
+    def constants(self) -> Dict:
+        return TVIPS_CONST
+
+    @property
+    def hasMeta(self) -> bool:
+        return False
 
 @dataclass
 class EigerDetector(DataClassJsonMixin):

--- a/src/nexgen/tools/mrc_tools.py
+++ b/src/nexgen/tools/mrc_tools.py
@@ -1,7 +1,11 @@
 """ Helper functions for the MRC to Nexus converter """
 
+import logging
 import os
+import re
 from math import sqrt
+from pathlib import Path
+from typing import Tuple, Union
 
 import h5py
 import hdf5plugin
@@ -9,17 +13,20 @@ import mrcfile
 import numpy as np
 
 
-def cal_wavelength(V0):
+def cal_wavelength(V0: float) -> float:
     """
-    Compute the relativistic electron wavelength from
-    the electron acceleration voltage.
+    Compute the relativistic electron wavelength from the electron
+    acceleration voltage.
 
-    Args:
-        V0 (int or float): acceleration voltage for electrons
-                           in Volts [V].
+    Arguments
+    ---------
+    V0 : int or float
+        Acceleration voltage for electrons in Volts.
 
-    Returns:
-        wlen (float): Electron wavelength in Angstroms.
+    Returns
+    -------
+    wlen : float
+        Electron wavelength in Angstroms.
 
     For an acceleration voltage of 200000 V, the electron energy
     is 200 keV (set by default if V0 is zero).
@@ -37,20 +44,28 @@ def cal_wavelength(V0):
     return wlen  # Electron wavelength in Angstroms
 
 
-def get_metadata(mrc_image, verbatim=True):
+def get_metadata(mrc_image: Union[str, Path], verbatim: bool = True) -> dict:
     """
-    Extract the metadata dictionary from a single MRC file.
+    Extract metadata dictionary from an MRC file.
 
-    Args:
-        mrc_image (Path or str): the MRC file path.
+    Arguments
+    ---------
+    mrc_image : Path or str
+        MRC file path.
 
-    Returns:
-        hd (dict): A dictionary containing metadata
-                   from the MRC file.
+    Returns
+    -------
+    hd : dict
+        A dictionary containing metadata from the MRC file.
 
-    The function extracts data from the MRC header and extended
-    header dictionaries.
+    The function extracts data from the MRC header and extended header
+    dictionaries.
     """
+    hd = {}  # Header dictionary
+
+    test_file = mrcfile.open(mrc_image, mode="r")
+    hd["data_shape"] = test_file.data.shape
+    hd["original_data_type"] = test_file.data.dtype
 
     with mrcfile.open(mrc_image, header_only=True) as mrc:
         h = mrc.header
@@ -59,7 +74,6 @@ def get_metadata(mrc_image, verbatim=True):
         except AttributeError:
             # For mrcfile versions older than 1.5.0
             xh = mrc.extended_header
-        hd = {}
 
         hd["nx"] = h["nx"]
         hd["ny"] = h["ny"]
@@ -94,12 +108,12 @@ def get_metadata(mrc_image, verbatim=True):
             / (hd["pixelSpacing"] * hd["wavelength"] * 1e-10)
             * 1000.0
         )
-
         if not is_FEI2:
             return hd
 
         hd["scanRotation"] = xh["Scan rotation"][0]
-        hd["diffractionPatternRotation"] = xh["Diffraction pattern rotation"][0]
+        var = "diffractionPatternRotation"
+        hd[var] = xh["Diffraction pattern rotation"][0]
         hd["imageRotation"] = xh["Image rotation"][0]
         hd["scanModeEnum"] = xh["Scan mode enumeration"][0]
         hd["acquisitionTimeStamp"] = xh["Acquisition time stamp"][0]
@@ -120,37 +134,51 @@ def get_metadata(mrc_image, verbatim=True):
         return hd
 
 
-def collect_data(files):
+def to_hdf5_data_file(
+    files: list[Union[str, Path]], logger: logging.Logger, dtype: str = None
+) -> Tuple[int, str, np.ndarray, np.dtype]:
     """
-    Extract image data from a list of MRC files into a single
-    HDF5 (h5) file.
+    Extracts data from an MRC format into HDF5
 
-    Args:
-        files (list of strings): A list containing names
-            of all MRC images.
+    Arguments
+    ---------
+        files : a list of strings or paths
+            A list of MRC files.
+        dtype : string, optional
+            Convert the original data from MRC to this type in HDF5.
+            Can be: 'uint16', 'uint32', 'uint64', 'int16', 'int32', 'int64',
+                    'float32', 'float64'.
+            Default is None, in which case the original data type will be
+            preserved during conversion.
 
-    Returns:
-        n (int): The total number of MRC images.
-        out_file (string): Name of the output h5 file.
-        angles (1D numpy array of floats): An array containing
-            tilt angles of all MRC images (as extracted from the
-            MRC metadata).
+    Returns
+    -------
+        hdf5_file :  string
+            Name of the output HDF5 file.
 
-    The function takes a list of MRC filenames, assuming that each
-    filename contains a single diffraction image (as a 2D array),
-    and makes a single h5 file containing a 3D array (where the first
-    index enumerates the images). The data is saved in the field
-    '/entry/data/data/' as an int32 and compressed using the LZ4
-    compression method. Note that the original data in the MRC files
-    is saved as a floating point number, although the actual data
-    consists solely of integers. The function also assumes that all
-    MRC files end with an indexing number: like 'basename_00001.mrc',
-    in which case the data is saved in 'basename.h5'.
+    Converts MRC data to HDF5. The input can be either a list of individual
+    MRC images, or a single MRC file with a stack of images. In the first
+    case, the function assumes that all MRC files end with an indexing number
+    (e.g. some_basename_00001.mrc) and removes everything after the last '_'
+    (e.g. the output is some_basename.h5). In the second case (a single MRC
+    input file) the function only replaces the '.mrc' extension with '.h5'.
+    The HDF5 output contains a 3D array (saved in the field
+    '/entry/data/data'), where the first index enumerates the images.
     """
 
-    out_file = files[0].rsplit("_", 1)[0] + ".h5"
+    # Remove everything after the last '_' from the file name (the indexing)
+    out_file = os.path.basename(files[0])
+
+    ends_with_number = re.search(r"_(\d+)\.mrc", out_file)
+
+    if ends_with_number:
+        out_file = out_file.rsplit("_", 1)[0] + ".h5"
+    else:
+        out_file = out_file.replace(".mrc", ".h5")
+
     mrc_files = []
-    angles = []
+
+    # Filter only MRC files from the input
     for file in files:
         path = os.path.abspath(file)
         if path.endswith(".mrc"):
@@ -160,43 +188,87 @@ def collect_data(files):
 
     test_file = mrcfile.open(mrc_files[0], mode="r")
     data_shape = test_file.data.shape
+
+    if not dtype:
+        dtype = test_file.data.dtype
+    else:
+        dtype = np.dtype(dtype)  # Convert the string to dtype
+
     test_file.close()
-    if len(data_shape) != 2:
-        msg = "The converter works only with individual MRC images"
-        raise ValueError(msg)
 
-    with h5py.File(out_file, "w") as hdf5_file:
-        dataset_shape = (n, data_shape[0], data_shape[1])
-        dataset = hdf5_file.create_dataset(
-            "data_temp", shape=dataset_shape, dtype=np.int32
-        )
+    # Input is a single MRC file with a stack of images
+    if (len(data_shape) == 3) and (n == 1):
 
-        group = hdf5_file.create_group("entry")
-        group.attrs["NX_class"] = np.bytes_("NXentry")
-        data_group = group.create_group("data")
-        data_group.attrs["NX_class"] = np.bytes_("NXdata")
+        with h5py.File(out_file, "w") as hdf5_file:
 
-        compressed_data = hdf5_file.create_dataset(
-            "/entry/data/data", shape=dataset_shape, dtype=np.int32, **hdf5plugin.LZ4()
-        )
+            mrc = mrcfile.open(files[0], mode="r")
 
-        for i, file in enumerate(mrc_files):
-            print(" Reading image %d:  %s" % (i, file))
-            mrc = mrcfile.open(file, mode="r")
-            data = np.array(mrc.data, dtype=np.int32)
-            try:
-                xh = mrc.indexed_extended_header
-            except AttributeError:
-                xh = mrc.extended_header
+            bs = hdf5plugin.Bitshuffle
+            dataset_shape = (data_shape[0], data_shape[1], data_shape[2])
+            dataset = hdf5_file.create_dataset(
+                "data_temp",
+                shape=dataset_shape,
+                dtype=dtype,
+                **bs(clevel=3, cname="lz4"),
+            )
 
-            if "Alpha tilt" in xh.dtype.names:
-                angles.append(xh["Alpha tilt"][0])
-            else:
-                angles.append(None)
-            dataset[i, :, :] = data
+            group = hdf5_file.create_group("entry")
+            group.attrs["NX_class"] = np.bytes_("NXentry")
+            data_group = group.create_group("data")
+            data_group.attrs["NX_class"] = np.bytes_("NXdata")
+
+            compressed_data = hdf5_file.create_dataset(
+                "/entry/data/data",
+                shape=dataset_shape,
+                dtype=dtype,
+                **bs(clevel=3, cname="lz4"),
+            )
+
+            dataset[:, :, :] = mrc.data
             mrc.close()
 
-        compressed_data[...] = dataset[...]
-        del hdf5_file["data_temp"]
+            compressed_data[...] = dataset[...]
+            del hdf5_file["data_temp"]
 
-        return n, out_file, np.array(angles)
+            return out_file
+
+    # Input is a list of MRC files containing single images
+    elif (len(data_shape) == 2) and (n >= 1):
+
+        with h5py.File(out_file, "w") as hdf5_file:
+            dataset_shape = (n, data_shape[0], data_shape[1])
+            dataset = hdf5_file.create_dataset(
+                "data_temp", shape=dataset_shape, dtype=dtype
+            )
+
+            group = hdf5_file.create_group("entry")
+            group.attrs["NX_class"] = np.bytes_("NXentry")
+            data_group = group.create_group("data")
+            data_group.attrs["NX_class"] = np.bytes_("NXdata")
+
+            field = "/entry/data/data"
+            compressed_data = hdf5_file.create_dataset(
+                field, shape=dataset_shape, dtype=dtype, **hdf5plugin.LZ4()
+            )
+
+            for i, file in enumerate(mrc_files):
+                logger.info("Reading image %d:  %s" % (i, file))
+                mrc = mrcfile.open(file, mode="r")
+                data = np.array(mrc.data, dtype=dtype)
+
+                if len(data.shape) > 2:
+                    msg = "MRC file contains more than a single image\n"
+                    msg += f"  File: {file}"
+                    raise ValueError(msg)
+
+                dataset[i, :, :] = data
+                mrc.close()
+
+            compressed_data[...] = dataset[...]
+            del hdf5_file["data_temp"]
+
+            return out_file
+    else:
+        msg = "The converter expects either a list of MRC images\n"
+        msg += "or a single MRC file with a stack of images."
+        raise ValueError(msg)

--- a/src/nexgen/utils.py
+++ b/src/nexgen/utils.py
@@ -6,10 +6,9 @@ from __future__ import annotations
 
 import logging
 import re
-from collections import namedtuple
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, NamedTuple, Tuple
 
 import h5py
 import numpy as np
@@ -31,9 +30,15 @@ __all__ = [
 MAX_FRAMES_PER_DATASET = 1000
 MAX_SUFFIX_DIGITS = 6
 
+
 # Define coordinates
-Point3D = namedtuple("Point3D", ("x", "y", "z"))
-Point3D.__doc__ = """Coordinates in 3D space."""
+class Point3D(NamedTuple):
+    """Coordinates (x,y,z) in 3D space."""
+
+    x: float
+    y: float
+    z: float
+
 
 # Filename pattern: filename_######.h5 or filename_meta.h5
 # P = re.compile(r"(.*)_(?:\d+)")
@@ -210,7 +215,15 @@ def units_of_time(q: str) -> Q_:  # -> pint.Quantity:
         )
 
 
-def get_iso_timestamp(ts: str | float) -> str:
+def _validate_timestamp_string(ts: str, fmt: str) -> bool:
+    try:
+        res = bool(datetime.strptime(ts, fmt))
+    except ValueError:
+        res = False
+    return res
+
+
+def get_iso_timestamp(ts: str | float | None) -> str:
     """
     Format a timestamp string to be stores in a NeXus file according to ISO8601: 'YY-MM-DDThh:mm:ssZ'
 
@@ -223,6 +236,7 @@ def get_iso_timestamp(ts: str | float) -> str:
     """
     # Format strings for timestamps
     format_list = [
+        "%Y-%m-%dT%H:%M:%SZ",  # ISO8601 formatted string
         "%Y-%m-%dT%H:%M:%S",
         "%Y-%m-%d %H:%M:%S",
         "%a %b %d %Y %H:%M:%S",
@@ -230,15 +244,29 @@ def get_iso_timestamp(ts: str | float) -> str:
     ]
     if ts is None:
         return None
-    try:
+
+    ts_iso = None
+    if isinstance(ts, float):
         ts = float(ts)
-        ts_iso = datetime.utcfromtimestamp(ts).replace(microsecond=0).isoformat()
-    except ValueError:
+        ts_iso = (
+            datetime.fromtimestamp(ts, tz=timezone.utc)
+            .replace(microsecond=0)
+            .isoformat()
+        )
+        ts_iso = ts_iso.removesuffix("+00:00")  # Remove timezone indication
+    elif isinstance(ts, str):
         for fmt in format_list:
-            try:
+            if _validate_timestamp_string(ts, fmt) is True:
                 ts_iso = datetime.strptime(ts, fmt).isoformat()
-            except ValueError:
-                ts_iso = str(ts)
+                break
+        if not ts_iso:
+            raise ValueError(
+                f"Unknown format. Unable to validate timestamp string, please pass one of: {format_list}"
+            )
+    else:
+        raise ValueError(
+            "Please pass the timestamp either as a time.time float or a formatted string."
+        )
     if ts_iso.endswith("Z") is False:
         ts_iso += "Z"
     return ts_iso

--- a/tests/beamlines/test_beamline_utils.py
+++ b/tests/beamlines/test_beamline_utils.py
@@ -14,7 +14,7 @@ def test_pump_probe():
 
 
 def test_pump_probe_dict():
-    pump_probe = PumpProbe().dict()
+    pump_probe = PumpProbe().model_dump()
     assert list(pump_probe.keys()) == [
         "pump_status",
         "pump_exposure",

--- a/tests/beamlines/test_i19nxs.py
+++ b/tests/beamlines/test_i19nxs.py
@@ -1,25 +1,111 @@
 from __future__ import annotations
 
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from nexgen.beamlines.I19_2_nxs import ExperimentTypeError, eiger_writer, nexus_writer
+from nexgen.beamlines.I19_2_nxs import (
+    CollectionParams,
+    DetAxisPosition,
+    DetectorName,
+    GonioAxisPosition,
+    eiger_writer,
+    serial_nexus_writer,
+)
 
 
-def test_nexus_writer_raises_error_for_serial():
-    with pytest.raises(ExperimentTypeError):
-        nexus_writer("/path/to/meta", "eiger", 0.1, serial=True)
+@pytest.fixture
+def dummy_eiger_collection_params():
+    return CollectionParams(
+        exposure_time=0.01,
+        beam_center=(100, 200),
+        wavelength=0.4,
+        metafile="/path/to/somefile_meta.h5",
+        detector_name=DetectorName.EIGER,
+    )
 
 
-@patch("nexgen.beamlines.I19_2_nxs.log")
-def test_nexus_writer_fails_if_missing_n_imgs_and_not_using_meta(fake_log):
+@pytest.fixture
+def dummy_tristan_collection_params():
+    return CollectionParams(
+        exposure_time=300,
+        beam_center=(100, 200),
+        wavelength=0.4,
+        metafile="/path/to/somefile_meta.h5",
+        detector_name=DetectorName.TRISTAN,
+        axes_pos=[
+            GonioAxisPosition(id="omega", start=-90, end=-20),
+            GonioAxisPosition(id="phi", start=0.0),
+        ],
+        det_pos=[DetAxisPosition(id="det_z", start=250.0)],
+    )
+
+
+@patch("nexgen.beamlines.I19_2_nxs.log.config")
+def test_nexus_writer_fails_if_missing_n_imgs_and_not_using_meta(
+    mock_log_config, dummy_eiger_collection_params
+):
+    dummy_eiger_collection_params.tot_num_images = None
     with pytest.raises(ValueError):
-        nexus_writer("/path/to/meta", "eiger", 0.1, use_meta=False)
+        eiger_writer(
+            Path("/path/to/master.nxs"), dummy_eiger_collection_params, use_meta=False
+        )
 
 
-@patch("nexgen.beamlines.I19_2_nxs.CollectionParams")
-def test_eiger_nxs_writer_fails_if_missing_axes_and_no_meta(fake_params):
+def test_eiger_nxs_writer_fails_if_missing_axes_and_no_meta(
+    dummy_eiger_collection_params,
+):
     with pytest.raises(ValueError):
-        eiger_writer(Path("/path/to/meta"), fake_params, use_meta=False)
+        eiger_writer(
+            Path("/path/to/meta"), dummy_eiger_collection_params, use_meta=False
+        )
+
+
+@patch("nexgen.beamlines.I19_2_nxs.logger")
+@patch("nexgen.beamlines.I19_2_nxs.log.config")
+@patch("nexgen.beamlines.I19_2_nxs.eiger_writer")
+def test_serial_nexus_writer_calls_correct_writer_for_eiger(
+    mock_eiger_writer, mock_log_config, mock_logger, dummy_eiger_collection_params
+):
+    serial_nexus_writer(
+        dummy_eiger_collection_params.model_dump(),
+        Path("path/to/somefile.nxs"),
+        (None, None),
+        use_meta=True,
+    )
+
+    mock_log_config.assert_called_once()
+    mock_eiger_writer.assert_called_once_with(
+        Path("path/to/somefile.nxs"),
+        dummy_eiger_collection_params,
+        (None, None),
+        True,
+        None,
+        0,
+        None,
+    )
+
+
+@patch("nexgen.beamlines.I19_2_nxs.logger")
+@patch("nexgen.beamlines.I19_2_nxs.log.config")
+@patch("nexgen.beamlines.I19_2_nxs.tristan_writer")
+def test_serial_nexus_writer_calls_correct_writer_for_tristan(
+    mock_tristan_writer, mock_log_config, mock_logger, dummy_tristan_collection_params
+):
+    start_time = datetime.strptime("2025-05-19T11:59:02", "%Y-%m-%dT%H:%M:%S")
+    serial_nexus_writer(
+        dummy_tristan_collection_params.model_dump(),
+        Path("path/to/somefile.nxs"),
+        (start_time, None),
+        use_meta=True,
+    )
+
+    assert mock_logger.info.call_count == 4
+    mock_tristan_writer.assert_called_once_with(
+        Path("path/to/somefile.nxs"),
+        dummy_tristan_collection_params,
+        ("2025-05-19T11:59:02Z", None),
+        None,
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import time
+from datetime import datetime
 from pathlib import Path
 
 import numpy as np
@@ -66,6 +67,30 @@ def test_iso_timestamps():
     assert utils.get_iso_timestamp(None) is None
     # Check that no exceptions are raised when passing a time.time() object
     assert utils.get_iso_timestamp(time.time())
+
+
+def test_iso_timestamps_fails_for_wrong_input_type():
+    with pytest.raises(ValueError):
+        utils.get_iso_timestamp(datetime.now())
+
+
+@pytest.mark.parametrize(
+    "ts, expected_iso",
+    [
+        ("2023-10-15T20:12:26", "2023-10-15T20:12:26Z"),
+        ("2024-03-12 11:35:01", "2024-03-12T11:35:01Z"),
+        ("Mon May 19 2025 10:45:28", "2025-05-19T10:45:28Z"),
+    ],
+)
+def test_get_iso_timestamp_from_time_string(ts, expected_iso):
+    iso_ts = utils.get_iso_timestamp(ts)
+
+    assert iso_ts == expected_iso
+
+
+def test_iso_timestamp_fails_for_unknown_format():
+    with pytest.raises(ValueError):
+        utils.get_iso_timestamp("19-05-2025 14:25:01")
 
 
 def test_units_of_length():

--- a/tests/tools/test_mrc_tools.py
+++ b/tests/tools/test_mrc_tools.py
@@ -1,0 +1,56 @@
+import os
+
+import mrcfile
+import numpy as np
+
+from nexgen.tools.mrc_tools import cal_wavelength, collect_data, get_metadata
+
+
+def test_cal_wavelength():
+
+    a = 0.025082356047905176
+    epsilon = 1.0e-15
+    assert abs(cal_wavelength(200000) - a) < epsilon
+
+
+def test_get_metadata():
+
+    make_mrc_file("images.mrc")
+    h = get_metadata("images.mrc")
+    assert isinstance(h, dict)
+
+    os.remove("images.mrc")
+
+
+def test_collect_data():
+
+    make_mrc_file("images_00001.mrc")
+    make_mrc_file("images_00002.mrc")
+
+    n, hdf5_file, angles = collect_data(["images_00001.mrc", "images_00002.mrc"])
+    assert n == 2
+    assert os.path.exists("images.h5")
+
+    os.remove("images_00001.mrc")
+    os.remove("images_00002.mrc")
+    os.remove("images.h5")
+
+
+def make_mrc_file(filename):
+
+    images = np.zeros((1, 1), dtype=np.int16)
+
+    with mrcfile.new(filename, overwrite=True) as mrc:
+        mrc.set_data(images)
+
+        mrc.voxel_size = 1.0  # example voxel size in angstroms
+        mrc.header.nxstart = 0
+        mrc.header.nystart = 0
+        mrc.header.nzstart = 0
+        mrc.header.nx = 1
+        mrc.header.ny = 1
+        mrc.header.nz = 1
+        mrc.header.mx = 1
+        mrc.header.my = 1
+        mrc.header.mz = 1
+        mrc.header.exttyp = np.array("CCP4", dtype="S")

--- a/tests/tools/test_mrc_tools.py
+++ b/tests/tools/test_mrc_tools.py
@@ -1,9 +1,12 @@
+import logging
 import os
 
 import mrcfile
 import numpy as np
 
-from nexgen.tools.mrc_tools import cal_wavelength, collect_data, get_metadata
+from nexgen.tools.mrc_tools import cal_wavelength, get_metadata, to_hdf5_data_file
+
+logger = logging.getLogger("nexgen.ED_mrc_to_nexus")
 
 
 def test_cal_wavelength():
@@ -27,8 +30,9 @@ def test_collect_data():
     make_mrc_file("images_00001.mrc")
     make_mrc_file("images_00002.mrc")
 
-    n, hdf5_file, angles = collect_data(["images_00001.mrc", "images_00002.mrc"])
-    assert n == 2
+    files = ["images_00001.mrc", "images_00002.mrc"]
+    hdf5_file = to_hdf5_data_file(files, logger)
+    assert hdf5_file == "images.h5"
     assert os.path.exists("images.h5")
 
     os.remove("images_00001.mrc")


### PR DESCRIPTION
Extend ED_mrc_to_nexus command to work with TVIPS cameras (besides eBIC Ceta-D detector). The command now has an option --detector that could be set either to cetad or tvips.